### PR TITLE
chore: maintainer sync toolkit 0.4.3

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,6 @@
 name: Pull Request
 
 on:
-  workflow_dispatch:
   pull_request:
     types:
       - opened
@@ -17,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
 
       - name: Restoring node_modules cache
         uses: actions/cache@v5
@@ -66,20 +65,13 @@ jobs:
       image: semgrep/semgrep
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Semgrep scan
         run: |
-          if [ -n "${{ github.event.pull_request.base.sha }}" ]; then
-            BASELINE="${{ github.event.pull_request.base.sha }}"
-          else
-            BASE="${{ github.event.repository.default_branch }}"
-            git config --global --add safe.directory "$(pwd)"
-            git fetch origin "${BASE}"
-            BASELINE="$(git merge-base HEAD "origin/${BASE}")"
-          fi
+          BASELINE="${{ github.event.pull_request.base.sha }}"
           semgrep scan \
             --config p/ci \
             --config p/javascript \

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ test: start
 	@$(exec_on_docker) yarn type-check
 
 # >>> rosey-maintainer:ops-docker BEGIN
-# Managed by rosey-maintainer-tools 0.4.2. Do not edit directly.
+# Managed by rosey-maintainer-tools 0.4.3. Do not edit directly.
 
 PROJECT_NAME ?= luisalejandro-org
 all_ps_hashes = $(shell docker ps -q)
@@ -110,7 +110,7 @@ cataplum:
 # <<< rosey-maintainer:ops-docker END
 
 # >>> rosey-maintainer:ops-release BEGIN
-# Managed by rosey-maintainer-tools 0.4.2. Do not edit directly.
+# Managed by rosey-maintainer-tools 0.4.3. Do not edit directly.
 
 release:
 	@./scripts/release.sh $${VERSION_TYPE}

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Shared release gates for release scripts.
-# Managed by rosey-maintainer-tools 0.4.2. Do not edit directly.
+# Managed by rosey-maintainer-tools 0.4.3. Do not edit directly.
 
 RELEASE_CI_WORKFLOW=${RELEASE_CI_WORKFLOW:-push.yml}
 RELEASE_CI_TIMEOUT_SECONDS=${RELEASE_CI_TIMEOUT_SECONDS:-2700}


### PR DESCRIPTION
## Summary
- Remove `workflow_dispatch` from `pr.yml` (CI retriggers via `pull_request` `synchronize` only).
- Simplify managed **Code Quality** Semgrep job to use `github.event.pull_request.base.sha`.
- Toolkit **0.4.3** manifest + Makefile/lib.sh sync.

## Test plan
- [ ] **Pull Request** workflow runs on this PR (no dispatch trigger).
- [ ] **Code Quality** job passes.
- [ ] Rulesets already updated via `rosey-maintain protect-github --apply`.