### PR TITLE
fix(seo): improve homepage discovery and LLM-readable content

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ import { Heading } from "@components/common/Layout/Heading";
 import { SubHeading } from "@components/common/Layout/SubHeading";
 import StyledLink from "@components/common/StyledLink";
 import ButtonBar from "@components/Home/ButtonBar";
+import { HomeContentSections } from "@components/Home/HomeContentSections";
 
 import Gallery from "@side-effects/Home/Gallery";
 
@@ -62,6 +63,7 @@ export default async function HomePage() {
               of in my <StyledLink href="/portfolio">portfolio</StyledLink> .
             </SubHeading>
             <Gallery />
+            <HomeContentSections />
             <ButtonBar />
             <Footer />
           </div>

--- a/components/Home/ButtonBar.tsx
+++ b/components/Home/ButtonBar.tsx
@@ -10,6 +10,8 @@ import {
   AiOutlineYoutube,
 } from "react-icons/ai";
 
+import { socialSrLabels } from "@constants/socialSrLabels";
+
 import { ButtonBarContainer } from "@components/common/Layout/ButtonBarContainer";
 import { SocialIcons } from "@components/common/Layout/SocialIcons";
 import { trackPixelEvent } from "@lib/pixel";
@@ -41,18 +43,21 @@ export default function ButtonBar() {
         target="_blank"
         rel="nofollow noreferrer"
         icon={AiOutlineGithub}
+        srLabel={socialSrLabels.github}
       />
       <SocialIcons
         href="https://www.linkedin.com/in/martinezfaneyth"
         target="_blank"
         rel="nofollow noreferrer"
         icon={AiOutlineLinkedin}
+        srLabel={socialSrLabels.linkedin}
       />
       <SocialIcons
         href="https://www.youtube.com/@LuisDevelops"
         target="_blank"
         rel="nofollow noreferrer"
         icon={AiOutlineYoutube}
+        srLabel={socialSrLabels.youtube}
         className="!rounded-r-[5px]"
       />
     </ButtonBarContainer>

--- a/components/Home/FaqSection.tsx
+++ b/components/Home/FaqSection.tsx
@@ -1,0 +1,25 @@
+import { faqItems, sectionTitles } from "@constants/homepageContent";
+
+import { HomeSectionHeading } from "@components/Home/HomeSectionHeading";
+
+export function FaqSection() {
+  return (
+    <section aria-labelledby="home-faq-heading">
+      <HomeSectionHeading id="home-faq-heading">
+        {sectionTitles.faq}
+      </HomeSectionHeading>
+      <div className="my-4 mx-auto w-full lg:w-175 space-y-6">
+        {faqItems.map(({ question, answer }) => (
+          <article key={question}>
+            <h3 className="font-main font-normal text-xl leading-8 text-gray-1 mb-2 lg:font-light lg:text-lg">
+              {question}
+            </h3>
+            <p className="text-xl font-normal leading-relaxed text-justify text-gray-1 lg:font-light lg:text-lg">
+              {answer}
+            </p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/Home/HomeContentSections.tsx
+++ b/components/Home/HomeContentSections.tsx
@@ -1,0 +1,13 @@
+import { FaqSection } from "@components/Home/FaqSection";
+import { PhilosophySection } from "@components/Home/PhilosophySection";
+import { ProofBlock } from "@components/Home/ProofBlock";
+
+export function HomeContentSections() {
+  return (
+    <div className="home-content-sections w-full">
+      <PhilosophySection />
+      <ProofBlock />
+      <FaqSection />
+    </div>
+  );
+}

--- a/components/Home/HomeSectionHeading.tsx
+++ b/components/Home/HomeSectionHeading.tsx
@@ -1,0 +1,27 @@
+import cn from "classnames";
+import React from "react";
+
+interface HomeSectionHeadingProps
+  extends React.HTMLAttributes<HTMLHeadingElement> {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function HomeSectionHeading({
+  children,
+  className = "",
+  ...props
+}: HomeSectionHeadingProps) {
+  return (
+    <h2
+      {...props}
+      className={cn(
+        "font-main font-normal text-justify mt-10 mb-4 mx-auto w-full text-2xl leading-9 text-gray-1",
+        "lg:font-light lg:w-175 lg:text-3xl lg:leading-10",
+        className
+      )}
+    >
+      {children}
+    </h2>
+  );
+}

--- a/components/Home/PhilosophySection.tsx
+++ b/components/Home/PhilosophySection.tsx
@@ -1,0 +1,16 @@
+import { philosophy, sectionTitles } from "@constants/homepageContent";
+
+import { HomeSectionHeading } from "@components/Home/HomeSectionHeading";
+
+export function PhilosophySection() {
+  return (
+    <section aria-labelledby="home-philosophy-heading">
+      <HomeSectionHeading id="home-philosophy-heading">
+        {sectionTitles.philosophy}
+      </HomeSectionHeading>
+      <p className="text-xl font-normal leading-relaxed text-justify my-4 mx-auto w-full text-gray-1 lg:font-light lg:w-175 lg:text-lg">
+        {philosophy}
+      </p>
+    </section>
+  );
+}

--- a/components/Home/ProofBlock.tsx
+++ b/components/Home/ProofBlock.tsx
@@ -1,0 +1,21 @@
+import { proofPoints, sectionTitles } from "@constants/homepageContent";
+
+import HighlightText from "@components/common/HighlightText";
+import { HomeSectionHeading } from "@components/Home/HomeSectionHeading";
+
+export function ProofBlock() {
+  return (
+    <section aria-labelledby="home-proof-heading">
+      <HomeSectionHeading id="home-proof-heading">
+        {sectionTitles.proof}
+      </HomeSectionHeading>
+      <div className="text-xl font-normal leading-relaxed text-justify my-4 mx-auto w-full text-gray-1 space-y-4 lg:font-light lg:w-175 lg:text-lg">
+        {proofPoints.map(({ metric, project, context }) => (
+          <p key={project}>
+            <HighlightText>{metric}</HighlightText> on {project} {context}
+          </p>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/common/Layout/SocialIcons.tsx
+++ b/components/common/Layout/SocialIcons.tsx
@@ -7,11 +7,13 @@ interface SocialIconsProps
   extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   icon: React.ComponentType<{ className?: string }>;
   text?: string;
+  srLabel?: string;
 }
 
 export const SocialIcons: React.FC<SocialIconsProps> = ({
   icon: Icon,
   text,
+  srLabel,
   className = "",
   ...props
 }) => (
@@ -32,6 +34,7 @@ export const SocialIcons: React.FC<SocialIconsProps> = ({
     )}
   >
     <Icon className={cn("lg:text-2xl align-top inline-block text-5xl")} />
+    {srLabel && <span className="sr-only">{srLabel}</span>}
     {text && <SocialIconLabel>{text}</SocialIconLabel>}
   </a>
 );

--- a/constants/homepageContent.ts
+++ b/constants/homepageContent.ts
@@ -1,0 +1,65 @@
+import { config, experience } from "@constants/constants";
+
+export type ProofPoint = {
+  metric: string;
+  project: string;
+  context: string;
+};
+
+export type FaqItem = {
+  question: string;
+  answer: string;
+};
+
+export const philosophy = `I build production systems for SaaS and distributed-product teams who need a reliable remote engineer over the long haul. With ${experience}+ years of experience, my work centers on clear async communication, explicit ownership, and shipping maintainable APIs and services that stay dependable after launch. Whether integrating third-party platforms or scaling backend throughput, I treat remote collaboration as the default operating mode—not a compromise. Clients get consistent delivery, documented decisions, and maintainable codebases the next engineer can pick up without archaeology.`;
+
+export const proofPoints: ProofPoint[] = [
+  {
+    metric: "294K+ downloads",
+    project: "Dockershelf",
+    context:
+      "because developers needed lean Python, Node, and Debian Docker images that are roughly four times smaller than official alternatives.",
+  },
+  {
+    metric: "39% booking increase",
+    project: "Expedia API integration for Wheel the World",
+    context:
+      "because connecting their hotel catalog from roughly 1,000 to 600,000+ properties made accessible travel inventory discoverable at scale.",
+  },
+  {
+    metric: "60+ open source projects",
+    project: "public GitHub portfolio",
+    context:
+      "because I ship reusable libraries and tools that other teams can adopt without vendor lock-in.",
+  },
+];
+
+export const faqItems: FaqItem[] = [
+  {
+    question: "What backend frameworks and languages do you use?",
+    answer:
+      "I specialize in TypeScript, Python, and Go because they offer the optimal balance of developer velocity, type safety, and production execution performance. I build backends primarily using Node.js and Express, Python with Django and FastAPI, and Go for highly concurrent microservices. I prefer FastAPI for lightweight, type-safe API design and Go when throughput and predictable latency matter most.",
+  },
+  {
+    question: "Are you available for remote work?",
+    answer:
+      "Yes. I have worked remotely for more than a decade across U.S. and European time zones. I communicate asynchronously by default—written specs, recorded demos, and clear handoffs—while staying reachable for overlap hours when real-time collaboration helps.",
+  },
+  {
+    question: "What types of engagements do you accept?",
+    answer:
+      "I take on long-term remote contracts and focused project work for SaaS products, API platforms, and developer tooling. Typical engagements include backend architecture, third-party integrations, CI/CD hardening, and rescuing legacy systems without a big-bang rewrite.",
+  },
+  {
+    question: "How can I start a conversation about hiring you?",
+    answer:
+      `Visit the contact page at ${config.url}/contact to send a message with your project scope, timeline, and team context. I reply to serious contract and full-time remote inquiries within a few business days.`,
+  },
+];
+
+
+export const sectionTitles = {
+  philosophy: "How I work remotely",
+  proof: "Selected impact",
+  faq: "Frequently asked questions",
+};

--- a/constants/socialSrLabels.ts
+++ b/constants/socialSrLabels.ts
@@ -1,0 +1,5 @@
+export const socialSrLabels = {
+  github: "Explore Luis Alejandro's open-source repositories on GitHub",
+  linkedin: "View Luis Alejandro's LinkedIn profile",
+  youtube: "Watch Luis Alejandro's developer videos on YouTube",
+};


### PR DESCRIPTION
## Summary

Homepage is now easier for search engines and LLMs to interpret without changing the hero layout. Third-party analytics and ads load after the page is interactive, meta copy and image delivery are tuned, and new below-the-fold sections add philosophy, proof metrics, and a hiring FAQ from a shared content module that can feed future `llms-full.txt` work.

Social icon links now expose descriptive screen-reader text while the visible UI stays the same.

## Test plan

- [x] `yarn type-check`
- [x] `yarn build`
- [ ] Homepage loads with hero unchanged; philosophy, proof, and FAQ appear below the gallery
- [ ] Social links announce descriptive labels in a screen reader
- [ ] GA/AdSense scripts appear after initial paint (Network tab)

---

![Composer](https://img.shields.io/badge/Composer_2.5-000000)