### PR TITLE
fix(seo): semantic landmarks and accessibility shell (Phase 3)

### DIFF
--- a/app/apps/agoras/page.tsx
+++ b/app/apps/agoras/page.tsx
@@ -10,7 +10,7 @@ export default function AgorasPage() {
   return (
     <div className="w-full mx-auto">
       <Header />
-      <main>
+      <main id="main-content" tabIndex={-1}>
         <style jsx global>{`
           h1 {
             font-weight: 200;

--- a/app/apps/agoras/privacy/page.tsx
+++ b/app/apps/agoras/privacy/page.tsx
@@ -9,7 +9,7 @@ export default function AgorasPrivacyPage() {
   return (
     <div className="w-full mx-auto">
       <Header />
-      <main>
+      <main id="main-content" tabIndex={-1}>
         <style jsx global>{`
           h1 {
             font-weight: 200;

--- a/app/apps/agoras/terms/page.tsx
+++ b/app/apps/agoras/terms/page.tsx
@@ -9,7 +9,7 @@ export default function AgorasTermsPage() {
   return (
     <div className="w-full mx-auto">
       <Header />
-      <main>
+      <main id="main-content" tabIndex={-1}>
         <style jsx global>{`
           h1 {
             font-weight: 200;

--- a/app/blog/category/[slug]/page.tsx
+++ b/app/blog/category/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { logError } from "@lib/logger";
 
 import MoreStories from "@components/Blog/MoreStories";
 import { Section } from "@components/common/Layout/Section";
+import { WaveDivider } from "@components/common/Layout/WaveDivider";
 import LazyImagesLoader from "@components/LazyImagesLoader";
 import Footer from "@components/Portfolio/Footer/Footer";
 import Header from "@components/Portfolio/Header/Header";
@@ -29,11 +30,9 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
     return (
       <div className="bg-gray-6 text-black w-full my-0 mx-auto">
         <Header />
-        <main className="bg-white pb-50">
+        <main id="main-content" tabIndex={-1} className="bg-white pb-50">
           <BlogCategoryClient />
-          <svg viewBox="0 0 1920 200">
-            <path fill="#ddd" d="M960,50l960-50H0L960,50z" />
-          </svg>
+          <WaveDivider variant="200" />
           <Section grid overflowVisible oneColumn nopadding wide>
             <h1 className="text-4xl font-light leading-4 mt-0 mb-[10px]">
               Posts related to {categoryName}

--- a/app/blog/category/page.tsx
+++ b/app/blog/category/page.tsx
@@ -7,6 +7,7 @@ import { getAllCategories } from "@lib/api";
 import { logError } from "@lib/logger";
 
 import { Section } from "@components/common/Layout/Section";
+import { WaveDivider } from "@components/common/Layout/WaveDivider";
 import LazyImagesLoader from "@components/LazyImagesLoader";
 import Footer from "@components/Portfolio/Footer/Footer";
 import Header from "@components/Portfolio/Header/Header";
@@ -77,10 +78,8 @@ export default async function CategoriesPage() {
     return (
       <div className="bg-gray-6 text-black w-full my-0 mx-auto">
         <Header />
-        <main className="bg-white pb-50">
-          <svg viewBox="0 0 1920 200">
-            <path fill="#ddd" d="M960,50l960-50H0L960,50z" />
-          </svg>
+        <main id="main-content" tabIndex={-1} className="bg-white pb-50">
+          <WaveDivider variant="200" />
           <Section grid overflowVisible oneColumn nopadding wide>
             <div className="w-full px-[2%] py-8">
               <h1 className="text-4xl font-light leading-4 mt-0 mb-8 text-center">

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -6,6 +6,7 @@ import markdownToHtml from "@lib/markdownToHtml";
 import { generateBlogJsonLd } from "@lib/structuredData";
 
 import BlogSearchWrapper from "@components/Blog/BlogSearchWrapper";
+import { WaveDivider } from "@components/common/Layout/WaveDivider";
 import LazyImagesLoader from "@components/LazyImagesLoader";
 import Footer from "@components/Portfolio/Footer/Footer";
 import Header from "@components/Portfolio/Header/Header";
@@ -17,7 +18,7 @@ export default async function BlogPage() {
     const posts = await Promise.all(
       allPosts.map(async (post: any) => {
         // Check if teaser is already HTML (starts with <)
-        const teaserHtml = post.metadata?.teaser?.startsWith('<')
+        const teaserHtml = post.metadata?.teaser?.startsWith("<")
           ? post.metadata.teaser
           : await markdownToHtml(post.metadata?.teaser || "");
 
@@ -47,11 +48,9 @@ export default async function BlogPage() {
           }}
         />
         <Header />
-        <main className="bg-white pb-50">
+        <main id="main-content" tabIndex={-1} className="bg-white pb-50">
           <BlogClient />
-          <svg viewBox="0 0 1920 200">
-            <path fill="#ddd" d="M960,50l960-50H0L960,50z" />
-          </svg>
+          <WaveDivider variant="200" />
           <BlogSearchWrapper posts={posts} />
           <LazyImagesLoader />
         </main>

--- a/app/blog/posts/[slug]/page.tsx
+++ b/app/blog/posts/[slug]/page.tsx
@@ -10,6 +10,7 @@ import markdownToHtml from "@lib/markdownToHtml";
 import { generateBlogPostingJsonLd } from "@lib/structuredData";
 
 import { Section } from "@components/common/Layout/Section";
+import { WaveDivider } from "@components/common/Layout/WaveDivider";
 import Footer from "@components/Portfolio/Footer/Footer";
 import Header from "@components/Portfolio/Header/Header";
 import PostContent from "@components/Post/PostContent";
@@ -64,10 +65,8 @@ export default async function PostPage({ params }: PostPageProps) {
         />
         <div className="bg-gray-6 w-full mx-auto">
           <Header />
-          <main className="bg-white pb-50">
-            <svg viewBox="0 0 1920 200">
-              <path fill="#ddd" d="M960,50l960-50H0L960,50z" />
-            </svg>
+          <main id="main-content" tabIndex={-1} className="bg-white pb-50">
+            <WaveDivider variant="200" />
             <Section grid overflowVisible oneColumn nopadding wide>
               <PostContent
                 title={post.title}

--- a/app/case-studies/canaima/page.tsx
+++ b/app/case-studies/canaima/page.tsx
@@ -14,6 +14,7 @@ import Product from "@components/CaseStudies/Product";
 import Results from "@components/CaseStudies/Results";
 import ScrollTween from "@components/CaseStudies/ScrollTween";
 import Why from "@components/CaseStudies/Why";
+import { WaveDivider } from "@components/common/Layout/WaveDivider";
 import Contact from "@components/Portfolio/Contact/Contact";
 import Footer from "@components/Portfolio/Footer/Footer";
 import Header from "@components/Portfolio/Header/Header";
@@ -33,9 +34,9 @@ const CanaimaPage = () => {
   ];
   return (
     <div className="w-full">
-      <main>
+      <Header variant="case-studies" />
+      <main id="main-content" tabIndex={-1}>
         <div id="cases" className="bg-accent-7 text-gray-2">
-          <Header variant="case-studies" />
           <Controller>
             <div className="cases-content w-full text-lg font-main">
               <HeroIntro
@@ -93,15 +94,11 @@ const CanaimaPage = () => {
                     paused
                     className="w-full page-hero bg-case-studies-canaima-hero relative"
                   >
-                    <svg viewBox="0 0 1920 100">
-                      <path fill="#333" d="M960,50l960-50H0L960,50z" />
-                    </svg>
+                    <WaveDivider fill="#333" />
 
                     <div className="h-96" />
 
-                    <svg viewBox="0 0 1920 100">
-                      <path fill="#333" d="M1920,0v100H0V0l960,50L1920,0z" />
-                    </svg>
+                    <WaveDivider fill="#333" inverted />
                   </ScrollTween>
                 )}
               </Scene>
@@ -364,9 +361,9 @@ const CanaimaPage = () => {
             </div>
           </Controller>
           <Contact dark />
-          <Footer />
         </div>
       </main>
+      <Footer />
     </div>
   );
 };

--- a/app/case-studies/dockershelf/page.tsx
+++ b/app/case-studies/dockershelf/page.tsx
@@ -17,6 +17,7 @@ import Product from "@components/CaseStudies/Product";
 import Results from "@components/CaseStudies/Results";
 import ScrollTween from "@components/CaseStudies/ScrollTween";
 import Why from "@components/CaseStudies/Why";
+import { WaveDivider } from "@components/common/Layout/WaveDivider";
 import Contact from "@components/Portfolio/Contact/Contact";
 import Footer from "@components/Portfolio/Footer/Footer";
 import Header from "@components/Portfolio/Header/Header";
@@ -30,9 +31,9 @@ ChartJS.defaults.font.weight = 300;
 const DockershelfPage = () => {
   return (
     <div className="w-full">
-      <main>
+      <Header variant="case-studies" />
+      <main id="main-content" tabIndex={-1}>
         <div id="cases" className="bg-accent-7 text-gray-2">
-          <Header variant="case-studies" />
           <Controller>
             <div className="cases-content w-full text-lg font-main">
               <HeroIntro
@@ -88,15 +89,11 @@ const DockershelfPage = () => {
                     paused
                     className="w-full page-hero bg-case-studies-dockershelf-hero relative"
                   >
-                    <svg viewBox="0 0 1920 100">
-                      <path fill="#333" d="M960,50l960-50H0L960,50z" />
-                    </svg>
+                    <WaveDivider fill="#333" />
 
                     <div className="h-96" />
 
-                    <svg viewBox="0 0 1920 100">
-                      <path fill="#333" d="M1920,0v100H0V0l960,50L1920,0z" />
-                    </svg>
+                    <WaveDivider fill="#333" inverted />
                   </ScrollTween>
                 )}
               </Scene>
@@ -421,9 +418,9 @@ const DockershelfPage = () => {
             </div>
           </Controller>
           <Contact dark />
-          <Footer />
         </div>
       </main>
+      <Footer />
     </div>
   );
 };

--- a/app/case-studies/expedia/page.tsx
+++ b/app/case-studies/expedia/page.tsx
@@ -10,6 +10,7 @@ import Product from "@components/CaseStudies/Product";
 import Results from "@components/CaseStudies/Results";
 import ScrollTween from "@components/CaseStudies/ScrollTween";
 import Why from "@components/CaseStudies/Why";
+import { WaveDivider } from "@components/common/Layout/WaveDivider";
 import Contact from "@components/Portfolio/Contact/Contact";
 import Footer from "@components/Portfolio/Footer/Footer";
 import Header from "@components/Portfolio/Header/Header";
@@ -17,9 +18,9 @@ import Header from "@components/Portfolio/Header/Header";
 const ExpediaPage = () => {
   return (
     <div className="w-full">
-      <main>
+      <Header variant="case-studies" />
+      <main id="main-content" tabIndex={-1}>
         <div id="cases" className="bg-accent-7 text-gray-2">
-          <Header variant="case-studies" />
           <Controller>
             <div className="cases-content w-full text-lg font-main">
               <HeroIntro
@@ -64,15 +65,11 @@ const ExpediaPage = () => {
                     paused
                     className="w-full page-hero bg-case-studies-expedia-hero relative"
                   >
-                    <svg viewBox="0 0 1920 100">
-                      <path fill="#333" d="M960,50l960-50H0L960,50z" />
-                    </svg>
+                    <WaveDivider fill="#333" />
 
                     <div className="h-96" />
 
-                    <svg viewBox="0 0 1920 100">
-                      <path fill="#333" d="M1920,0v100H0V0l960,50L1920,0z" />
-                    </svg>
+                    <WaveDivider fill="#333" inverted />
                   </ScrollTween>
                 )}
               </Scene>
@@ -295,9 +292,9 @@ const ExpediaPage = () => {
             </div>
           </Controller>
           <Contact dark />
-          <Footer />
         </div>
       </main>
+      <Footer />
     </div>
   );
 };

--- a/app/case-studies/soleit/page.tsx
+++ b/app/case-studies/soleit/page.tsx
@@ -14,6 +14,7 @@ import Product from "@components/CaseStudies/Product";
 import Results from "@components/CaseStudies/Results";
 import ScrollTween from "@components/CaseStudies/ScrollTween";
 import Why from "@components/CaseStudies/Why";
+import { WaveDivider } from "@components/common/Layout/WaveDivider";
 import Contact from "@components/Portfolio/Contact/Contact";
 import Footer from "@components/Portfolio/Footer/Footer";
 import Header from "@components/Portfolio/Header/Header";
@@ -35,9 +36,9 @@ const SoleitPage = () => {
 
   return (
     <div className="w-full">
-      <main>
+      <Header variant="case-studies" />
+      <main id="main-content" tabIndex={-1}>
         <div id="cases" className="bg-accent-7 text-gray-2">
-          <Header variant="case-studies" />
           <Controller>
             <div className="cases-content w-full text-lg font-main">
               <HeroIntro
@@ -90,15 +91,11 @@ const SoleitPage = () => {
                     paused
                     className="w-full page-hero bg-case-studies-soleit-hero relative"
                   >
-                    <svg viewBox="0 0 1920 100">
-                      <path fill="#333" d="M960,50l960-50H0L960,50z" />
-                    </svg>
+                    <WaveDivider fill="#333" />
 
                     <div className="h-96" />
 
-                    <svg viewBox="0 0 1920 100">
-                      <path fill="#333" d="M1920,0v100H0V0l960,50L1920,0z" />
-                    </svg>
+                    <WaveDivider fill="#333" inverted />
                   </ScrollTween>
                 )}
               </Scene>
@@ -377,9 +374,9 @@ const SoleitPage = () => {
             </div>
           </Controller>
           <Contact dark />
-          <Footer />
         </div>
       </main>
+      <Footer />
     </div>
   );
 };

--- a/app/case-studies/wheeltheworld/page.tsx
+++ b/app/case-studies/wheeltheworld/page.tsx
@@ -17,6 +17,7 @@ import Product from "@components/CaseStudies/Product";
 import Results from "@components/CaseStudies/Results";
 import ScrollTween from "@components/CaseStudies/ScrollTween";
 import Why from "@components/CaseStudies/Why";
+import { WaveDivider } from "@components/common/Layout/WaveDivider";
 import Contact from "@components/Portfolio/Contact/Contact";
 import Footer from "@components/Portfolio/Footer/Footer";
 import Header from "@components/Portfolio/Header/Header";
@@ -30,9 +31,9 @@ ChartJS.defaults.font.weight = 300;
 const WheelTheWorldPage = () => {
   return (
     <div className="w-full">
-      <main>
+      <Header variant="case-studies" />
+      <main id="main-content" tabIndex={-1}>
         <div id="cases" className="bg-accent-7 text-gray-2">
-          <Header variant="case-studies" />
           <Controller>
             <div className="cases-content w-full text-lg font-main">
               <HeroIntro
@@ -76,15 +77,11 @@ const WheelTheWorldPage = () => {
                     paused
                     className="w-full page-hero bg-case-studies-wheeltheworld-hero relative"
                   >
-                    <svg viewBox="0 0 1920 100">
-                      <path fill="#333" d="M960,50l960-50H0L960,50z" />
-                    </svg>
+                    <WaveDivider fill="#333" />
 
                     <div className="h-96" />
 
-                    <svg viewBox="0 0 1920 100">
-                      <path fill="#333" d="M1920,0v100H0V0l960,50L1920,0z" />
-                    </svg>
+                    <WaveDivider fill="#333" inverted />
                   </ScrollTween>
                 )}
               </Scene>
@@ -362,9 +359,9 @@ const WheelTheWorldPage = () => {
             </div>
           </Controller>
           <Contact dark />
-          <Footer />
         </div>
       </main>
+      <Footer />
     </div>
   );
 };

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -8,7 +8,7 @@ export default function ContactPage() {
   return (
     <div className="w-full mx-auto bg-bright-gold min-h-screen">
       <Header />
-      <main>
+      <main id="main-content" tabIndex={-1}>
         <div className="container pb-80"></div>
         <Contact />
       </main>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -4,13 +4,15 @@ import Link from "next/link";
 import { Container } from "@components/common/Layout/Container";
 import { Footer } from "@components/common/Layout/Footer";
 import { Heading } from "@components/common/Layout/Heading";
+import { HomeSiteHeader } from "@components/common/Layout/HomeSiteHeader";
 import { SubHeading } from "@components/common/Layout/SubHeading";
 import ButtonBar from "@components/Home/ButtonBar";
 
 export default function NotFound() {
   return (
     <>
-      <main>
+      <HomeSiteHeader />
+      <main id="main-content" tabIndex={-1}>
         <Container>
           <div
             id="app"
@@ -34,11 +36,11 @@ export default function NotFound() {
                 The page you are looking for does not exist.
               </SubHeading>
               <ButtonBar />
-              <Footer />
             </div>
           </div>
         </Container>
       </main>
+      <Footer />
     </>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import HighlightText from "@components/common/HighlightText";
 import { Container } from "@components/common/Layout/Container";
 import { Footer } from "@components/common/Layout/Footer";
 import { Heading } from "@components/common/Layout/Heading";
+import { HomeSiteHeader } from "@components/common/Layout/HomeSiteHeader";
 import { SubHeading } from "@components/common/Layout/SubHeading";
 import StyledLink from "@components/common/StyledLink";
 import ButtonBar from "@components/Home/ButtonBar";
@@ -19,56 +20,58 @@ export default async function HomePage() {
   const homepageJsonLd = generateHomepageJsonLd();
 
   return (
-    <main>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify(homepageJsonLd),
-        }}
-      />
-      <Container>
-        <div
-          id="app"
-          className="flex flex-col items-center justify-center w-full h-full pt-15"
-        >
-          <div className="home inline-block w-full">
-            <Link href="/">
-              <Image
-                alt=""
-                className="mx-auto"
-                src="/images/logomin.svg"
-                height={200}
-                width={200}
-                sizes="(max-width: 768px) 150px, 200px"
-              />
-            </Link>
-            <Heading>
-              Hi, I&apos;m <HighlightText>Luis Alejandro</HighlightText>.
-              I&apos;m a <HighlightText>software engineer</HighlightText> from
-              Venezuela, working remotely since the invention of the phone.{" "}
-            </Heading>
-            <SubHeading>
-              I have more than{" "}
-              <HighlightText>{experience} years of experience</HighlightText> as
-              a full stack developer. I&apos;m an active{" "}
-              <StyledLink
-                href="https://github.com/LuisAlejandro"
-                target="_blank"
-                rel="nofollow noreferrer"
-              >
-                open source contributor
-              </StyledLink>{" "}
-              and like to <StyledLink href="/blog">write</StyledLink> about my
-              discoveries. You can check out the projects I&apos;ve been a part
-              of in my <StyledLink href="/portfolio">portfolio</StyledLink> .
-            </SubHeading>
-            <Gallery />
-            <HomeContentSections />
-            <ButtonBar />
-            <Footer />
-          </div>
-        </div>
-      </Container>
-    </main>
+    <>
+      <HomeSiteHeader />
+      <main id="main-content" tabIndex={-1}>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(homepageJsonLd),
+          }}
+        />
+        <Container>
+          <article className="flex flex-col items-center justify-center w-full h-full pt-15">
+            <div className="home inline-block w-full">
+              <Link href="/">
+                <Image
+                  alt=""
+                  className="mx-auto"
+                  src="/images/logomin.svg"
+                  height={200}
+                  width={200}
+                  sizes="(max-width: 768px) 150px, 200px"
+                />
+              </Link>
+              <Heading>
+                Hi, I&apos;m <HighlightText>Luis Alejandro</HighlightText>.
+                I&apos;m a <HighlightText>software engineer</HighlightText> from
+                Venezuela, working remotely since the invention of the
+                phone.{" "}
+              </Heading>
+              <SubHeading>
+                I have more than{" "}
+                <HighlightText>{experience} years of experience</HighlightText>{" "}
+                as a full stack developer. I&apos;m an active{" "}
+                <StyledLink
+                  href="https://github.com/LuisAlejandro"
+                  target="_blank"
+                  rel="nofollow noreferrer"
+                >
+                  open source contributor
+                </StyledLink>{" "}
+                and like to <StyledLink href="/blog">write</StyledLink> about my
+                discoveries. You can check out the projects I&apos;ve been a
+                part of in my{" "}
+                <StyledLink href="/portfolio">portfolio</StyledLink> .
+              </SubHeading>
+              <Gallery />
+              <HomeContentSections />
+              <ButtonBar />
+            </div>
+          </article>
+        </Container>
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -16,7 +16,7 @@ const Portfolio = () => {
   return (
     <div className="w-full mx-auto">
       <Header />
-      <main>
+      <main id="main-content" tabIndex={-1}>
         <Section grid overflowVisible>
           <Hero />
           <BackgroundAnimation />

--- a/components/CaseStudies/Challenge.tsx
+++ b/components/CaseStudies/Challenge.tsx
@@ -1,6 +1,7 @@
 import cn from "classnames";
 import { Scene } from "react-scrollmagic";
 
+import { WaveDivider } from "@components/common/Layout/WaveDivider";
 import ScrollTween from "./ScrollTween";
 
 interface ChallengeProps {
@@ -24,9 +25,7 @@ const Challenge = ({ Title, Content, bgImgClass }: ChallengeProps) => (
           : {}
       )}
     >
-      <svg viewBox="0 0 1920 100">
-        <path fill="#333" d="M960,50l960-50H0L960,50z" />
-      </svg>
+      <WaveDivider fill="#333" />
       <Scene
         triggerElement="#challenge"
         duration="200%"
@@ -111,9 +110,7 @@ const Challenge = ({ Title, Content, bgImgClass }: ChallengeProps) => (
         <div className="col-span-3"></div>
       </div>
 
-      <svg viewBox="0 0 1920 100">
-        <path fill="#333" d="M1920,0v100H0V0l960,50L1920,0z" />
-      </svg>
+      <WaveDivider fill="#333" inverted />
     </div>
   </div>
 );

--- a/components/CaseStudies/Results.tsx
+++ b/components/CaseStudies/Results.tsx
@@ -1,5 +1,6 @@
 import { Scene } from "react-scrollmagic";
 
+import { WaveDivider } from "@components/common/Layout/WaveDivider";
 import ScrollTween from "./ScrollTween";
 
 interface ResultsProps {
@@ -13,9 +14,7 @@ const Results = ({ Title, Content, links }: ResultsProps) => (
     id="results"
     className="w-full bg-gradient-to-tl from-gray-100 to-gray-300"
   >
-    <svg viewBox="0 0 1920 100">
-      <path fill="#333" d="M960,50l960-50H0L960,50z" />
-    </svg>
+    <WaveDivider fill="#333" />
     <Scene
       triggerElement="#results"
       duration="200%"
@@ -122,9 +121,7 @@ const Results = ({ Title, Content, links }: ResultsProps) => (
       <div className="lg:col-span-1"></div>
     </div>
 
-    <svg viewBox="0 0 1920 100">
-      <path fill="#aaa" d="M1920,0v100H0V0l960,50L1920,0z" />
-    </svg>
+    <WaveDivider fill="#aaa" inverted />
   </div>
 );
 

--- a/components/Portfolio/Acomplishments/Acomplishments.tsx
+++ b/components/Portfolio/Acomplishments/Acomplishments.tsx
@@ -1,6 +1,7 @@
 import { Stars } from "@constants/constants";
 
 import { Section } from "@components/common/Layout/Section";
+import { WaveDivider } from "@components/common/Layout/WaveDivider";
 
 import { Box } from "./Box";
 import { BoxNum } from "./BoxNum";
@@ -19,9 +20,7 @@ const Acomplishments = () => (
         ))}
       </Boxes>
     </Section>
-    <svg viewBox="0 0 1920 100">
-      <path fill="#f8d983" d="M960,50l960-50H0L960,50z" />
-    </svg>
+    <WaveDivider fill="#f8d983" />
   </>
 );
 

--- a/components/Portfolio/CaseStudies/CaseStudies.tsx
+++ b/components/Portfolio/CaseStudies/CaseStudies.tsx
@@ -8,6 +8,7 @@ import { ProjectList } from "@constants/constants";
 import { Section } from "@components/common/Layout/Section";
 import { SectionText } from "@components/common/Layout/SectionText";
 import { SectionTitle } from "@components/common/Layout/SectionTitle";
+import { WaveDivider } from "@components/common/Layout/WaveDivider";
 
 import About from "@assets/images/about.svg";
 
@@ -35,7 +36,7 @@ const CaseStudies = () => {
 
   return (
     <>
-      <svg viewBox="0 0 1920 100">
+      <svg viewBox="0 0 1920 100" aria-hidden="true">
         <path
           fill="#f8d983"
           fillOpacity="0.5"
@@ -68,9 +69,7 @@ const CaseStudies = () => {
           ))}
         </CardGrid>
       </Section>
-      <svg viewBox="0 0 1920 100">
-        <path fill="#f8d983" d="M960,50l960-50H0L960,50z" />
-      </svg>
+      <WaveDivider fill="#f8d983" />
     </>
   );
 };

--- a/components/Portfolio/Contact/Contact.tsx
+++ b/components/Portfolio/Contact/Contact.tsx
@@ -226,7 +226,7 @@ const Contact = ({ dark }: { dark?: boolean }) => {
             </div>
           </div>
         </form>
-        <svg viewBox="0 0 1920 37">
+        <svg viewBox="0 0 1920 37" aria-hidden="true">
           <path
             fill="#444"
             fillOpacity="0.5"

--- a/components/Portfolio/Footer/FooterWrapper.tsx
+++ b/components/Portfolio/Footer/FooterWrapper.tsx
@@ -8,7 +8,7 @@ interface FooterWrapperProps extends React.HTMLAttributes<HTMLElement> {
 export const FooterWrapper = React.forwardRef<HTMLElement, FooterWrapperProps>(
   ({ children, className, ...props }, ref) => {
     return React.createElement(
-      "section",
+      "footer",
       {
         ...props,
         ref,

--- a/components/Portfolio/Header/Header.tsx
+++ b/components/Portfolio/Header/Header.tsx
@@ -15,12 +15,16 @@ import { Div1 } from "@components/common/Header/Div1";
 import { Div2 } from "@components/common/Header/Div2";
 import { Div3 } from "@components/common/Header/Div3";
 import { SocialIcons } from "@components/common/Header/SocialIcons";
+import { SkipToContentLink } from "@components/common/Layout/SkipToContentLink";
+import { WaveDivider } from "@components/common/Layout/WaveDivider";
+import { socialSrLabels } from "@constants/socialSrLabels";
 import { trackPixelEvent } from "@lib/pixel";
 
 const Header = ({ variant }: { variant?: string }) => {
   const isCaseStudies = variant === "case-studies";
   return (
-    <>
+    <header>
+      <SkipToContentLink />
       <Container wide={isCaseStudies} dark={isCaseStudies}>
         <Div1>
           <Link href="/" className="flex items-center text-white">
@@ -37,68 +41,70 @@ const Header = ({ variant }: { variant?: string }) => {
             />
           </Link>
         </Div1>
-        <Div2>
-          <li className="mx-2 lg:mx-5 leading-15">
-            <Link
-              href="/portfolio"
-              className={cn(
-                "text-lg p-1 font-light transition-all duration-400 ease-in-out hover:cursor-pointer",
-                isCaseStudies
-                  ? "text-gray-400 hover:text-white"
-                  : "text-black/75 hover:text-black",
-                "lg:p-0 lg:text-xl"
-              )}
-            >
-              Portfolio
-            </Link>
-          </li>
-          <li className="mx-2 lg:mx-5 leading-15">
-            <Link
-              href="/blog"
-              className={cn(
-                "text-lg p-1 font-light transition-all duration-400 ease-in-out hover:cursor-pointer",
-                isCaseStudies
-                  ? "text-gray-400 hover:text-white"
-                  : "text-black/75 hover:text-black",
-                "lg:p-0 lg:text-xl"
-              )}
-            >
-              Blog
-            </Link>
-          </li>
-          <li className="mx-2 lg:mx-5 leading-15">
-            <Link
-              href="https://store.luisalejandro.org/"
-              target="_blank"
-              rel="nofollow noreferrer"
-              onClick={() => trackPixelEvent("ClickHeaderStore")}
-              className={cn(
-                "text-lg p-1 font-light transition-all duration-400 ease-in-out hover:cursor-pointer",
-                isCaseStudies
-                  ? "text-gray-400 hover:text-white"
-                  : "text-black/75 hover:text-black",
-                "lg:p-0 lg:text-xl"
-              )}
-            >
-              Store
-            </Link>
-          </li>
-          <li className="mx-2 lg:mx-5 leading-15">
-            <Link
-              href="/contact"
-              onClick={() => trackPixelEvent("ClickHeaderContact")}
-              className={cn(
-                "text-lg p-1 font-light transition-all duration-400 ease-in-out hover:cursor-pointer",
-                isCaseStudies
-                  ? "text-gray-400 hover:text-white"
-                  : "text-black/75 hover:text-black",
-                "lg:p-0 lg:text-xl"
-              )}
-            >
-              Contact
-            </Link>
-          </li>
-        </Div2>
+        <nav aria-label="Main Navigation">
+          <Div2>
+            <li className="mx-2 lg:mx-5 leading-15">
+              <Link
+                href="/portfolio"
+                className={cn(
+                  "text-lg p-1 font-light transition-all duration-400 ease-in-out hover:cursor-pointer",
+                  isCaseStudies
+                    ? "text-gray-400 hover:text-white"
+                    : "text-black/75 hover:text-black",
+                  "lg:p-0 lg:text-xl"
+                )}
+              >
+                Portfolio
+              </Link>
+            </li>
+            <li className="mx-2 lg:mx-5 leading-15">
+              <Link
+                href="/blog"
+                className={cn(
+                  "text-lg p-1 font-light transition-all duration-400 ease-in-out hover:cursor-pointer",
+                  isCaseStudies
+                    ? "text-gray-400 hover:text-white"
+                    : "text-black/75 hover:text-black",
+                  "lg:p-0 lg:text-xl"
+                )}
+              >
+                Blog
+              </Link>
+            </li>
+            <li className="mx-2 lg:mx-5 leading-15">
+              <Link
+                href="https://store.luisalejandro.org/"
+                target="_blank"
+                rel="nofollow noreferrer"
+                onClick={() => trackPixelEvent("ClickHeaderStore")}
+                className={cn(
+                  "text-lg p-1 font-light transition-all duration-400 ease-in-out hover:cursor-pointer",
+                  isCaseStudies
+                    ? "text-gray-400 hover:text-white"
+                    : "text-black/75 hover:text-black",
+                  "lg:p-0 lg:text-xl"
+                )}
+              >
+                Store
+              </Link>
+            </li>
+            <li className="mx-2 lg:mx-5 leading-15">
+              <Link
+                href="/contact"
+                onClick={() => trackPixelEvent("ClickHeaderContact")}
+                className={cn(
+                  "text-lg p-1 font-light transition-all duration-400 ease-in-out hover:cursor-pointer",
+                  isCaseStudies
+                    ? "text-gray-400 hover:text-white"
+                    : "text-black/75 hover:text-black",
+                  "lg:p-0 lg:text-xl"
+                )}
+              >
+                Contact
+              </Link>
+            </li>
+          </Div2>
+        </nav>
         <Div3>
           <SocialIcons
             dark={isCaseStudies}
@@ -106,7 +112,8 @@ const Header = ({ variant }: { variant?: string }) => {
             target="_blank"
             rel="nofollow noreferrer"
           >
-            <AiFillGithub size="30px" />
+            <AiFillGithub size="30px" aria-hidden="true" />
+            <span className="sr-only">{socialSrLabels.github}</span>
           </SocialIcons>
           <SocialIcons
             dark={isCaseStudies}
@@ -114,7 +121,8 @@ const Header = ({ variant }: { variant?: string }) => {
             target="_blank"
             rel="nofollow noreferrer"
           >
-            <AiFillLinkedin size="30px" />
+            <AiFillLinkedin size="30px" aria-hidden="true" />
+            <span className="sr-only">{socialSrLabels.linkedin}</span>
           </SocialIcons>
           <SocialIcons
             dark={isCaseStudies}
@@ -122,7 +130,8 @@ const Header = ({ variant }: { variant?: string }) => {
             target="_blank"
             rel="nofollow noreferrer"
           >
-            <AiFillYoutube size="30px" />
+            <AiFillYoutube size="30px" aria-hidden="true" />
+            <span className="sr-only">{socialSrLabels.youtube}</span>
           </SocialIcons>
           <SocialIcons
             dark={isCaseStudies}
@@ -130,16 +139,13 @@ const Header = ({ variant }: { variant?: string }) => {
             target="_blank"
             rel="nofollow noreferrer"
           >
-            <AiOutlineX size="30px" />
+            <AiOutlineX size="30px" aria-hidden="true" />
+            <span className="sr-only">{socialSrLabels.x}</span>
           </SocialIcons>
         </Div3>
       </Container>
-      {isCaseStudies && (
-        <svg viewBox="0 0 1920 100">
-          <path fill="#303030" d="M960,50l960-50H0L960,50z" />
-        </svg>
-      )}
-    </>
+      {isCaseStudies && <WaveDivider fill="#303030" />}
+    </header>
   );
 };
 

--- a/components/Portfolio/Journey/Journey.tsx
+++ b/components/Portfolio/Journey/Journey.tsx
@@ -11,7 +11,7 @@ import TimelineChart from "./TimelineChart";
 const Timeline = () => {
   return (
     <>
-      <svg viewBox="0 0 1920 100">
+      <svg viewBox="0 0 1920 100" aria-hidden="true">
         <path
           fill="#f8d983"
           fillOpacity="0.5"

--- a/components/common/Layout/Footer.tsx
+++ b/components/common/Layout/Footer.tsx
@@ -1,7 +1,7 @@
 export function Footer() {
   return (
-    <div className="footer flex justify-center items-center mx-auto text-black/40 mb-5 font-light font-main text-base">
+    <footer className="footer flex justify-center items-center mx-auto text-black/40 mb-5 font-light font-main text-base">
       &copy; {new Date().getFullYear()} Luis Martínez. All rights reserved.
-    </div>
+    </footer>
   );
 }

--- a/components/common/Layout/HomeSiteHeader.tsx
+++ b/components/common/Layout/HomeSiteHeader.tsx
@@ -1,0 +1,69 @@
+import Image from "next/image";
+import Link from "next/link";
+
+import { SkipToContentLink } from "@components/common/Layout/SkipToContentLink";
+
+export function HomeSiteHeader() {
+  return (
+    <header className="w-full bg-bright-gold">
+      <SkipToContentLink />
+      <div className="mx-auto flex max-w-[94%] flex-wrap items-center justify-between gap-4 py-4 font-main">
+        <Link href="/" className="flex items-center">
+          <Image
+            alt=""
+            src="/images/logomin.svg"
+            height={48}
+            width={48}
+            sizes="48px"
+          />
+        </Link>
+        <nav aria-label="Main Navigation">
+          <ul className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-lg font-light">
+            <li>
+              <Link
+                href="/"
+                className="text-black/75 transition-all duration-400 ease-in-out hover:cursor-pointer hover:text-black"
+              >
+                Home
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/portfolio"
+                className="text-black/75 transition-all duration-400 ease-in-out hover:cursor-pointer hover:text-black"
+              >
+                Portfolio
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/blog"
+                className="text-black/75 transition-all duration-400 ease-in-out hover:cursor-pointer hover:text-black"
+              >
+                Blog
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="https://store.luisalejandro.org/"
+                target="_blank"
+                rel="nofollow noreferrer"
+                className="text-black/75 transition-all duration-400 ease-in-out hover:cursor-pointer hover:text-black"
+              >
+                Store
+              </Link>
+            </li>
+            <li>
+              <Link
+                href="/contact"
+                className="text-black/75 transition-all duration-400 ease-in-out hover:cursor-pointer hover:text-black"
+              >
+                Contact
+              </Link>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/components/common/Layout/SkipToContentLink.tsx
+++ b/components/common/Layout/SkipToContentLink.tsx
@@ -1,0 +1,10 @@
+export function SkipToContentLink() {
+  return (
+    <a
+      href="#main-content"
+      className="sr-only focus:not-sr-only focus:absolute focus:z-[10000] focus:top-2 focus:left-2 focus:rounded focus:bg-white focus:px-4 focus:py-2 focus:text-black focus:shadow-md"
+    >
+      Skip to main content
+    </a>
+  );
+}

--- a/components/common/Layout/SocialIcons.tsx
+++ b/components/common/Layout/SocialIcons.tsx
@@ -3,8 +3,7 @@ import React from "react";
 
 import SocialIconLabel from "../SocialIconLabel";
 
-interface SocialIconsProps
-  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+interface SocialIconsProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   icon: React.ComponentType<{ className?: string }>;
   text?: string;
   srLabel?: string;
@@ -33,7 +32,10 @@ export const SocialIcons: React.FC<SocialIconsProps> = ({
       className
     )}
   >
-    <Icon className={cn("lg:text-2xl align-top inline-block text-5xl")} />
+    <Icon
+      className={cn("lg:text-2xl align-top inline-block text-5xl")}
+      aria-hidden={Boolean(text || srLabel)}
+    />
     {srLabel && <span className="sr-only">{srLabel}</span>}
     {text && <SocialIconLabel>{text}</SocialIconLabel>}
   </a>

--- a/components/common/Layout/WaveDivider.tsx
+++ b/components/common/Layout/WaveDivider.tsx
@@ -1,0 +1,28 @@
+interface WaveDividerProps {
+  variant?: "100" | "200";
+  fill?: string;
+  inverted?: boolean;
+  className?: string;
+}
+
+export function WaveDivider({
+  variant = "100",
+  fill = "#ddd",
+  inverted = false,
+  className,
+}: WaveDividerProps) {
+  const height = variant === "100" ? 100 : 200;
+  const path = inverted
+    ? "M1920,0v100H0V0l960,50L1920,0z"
+    : "M960,50l960-50H0L960,50z";
+
+  return (
+    <svg
+      viewBox={`0 0 1920 ${height}`}
+      aria-hidden="true"
+      className={className}
+    >
+      <path fill={fill} d={path} />
+    </svg>
+  );
+}

--- a/constants/constants.ts
+++ b/constants/constants.ts
@@ -51,6 +51,9 @@ export const SES_COMPANY_TEMPLATE_ID = "luisalejandro-company";
 export const canonicalHostnameUrl =
   ENV_NAME === "local" ? "http://localhost:3101" : "https://luisalejandro.org";
 
+export const SITE_PROFILE_DATE_CREATED = "2020-01-15T08:00:00+00:00";
+export const SITE_PROFILE_DATE_MODIFIED = "2026-06-22T00:00:00+00:00";
+
 export const config = {
   name: "Luis Alejandro",
   app_name: "Luis Alejandro",

--- a/constants/socialSrLabels.ts
+++ b/constants/socialSrLabels.ts
@@ -2,4 +2,5 @@ export const socialSrLabels = {
   github: "Explore Luis Alejandro's open-source repositories on GitHub",
   linkedin: "View Luis Alejandro's LinkedIn profile",
   youtube: "Watch Luis Alejandro's developer videos on YouTube",
+  x: "Follow Luis Alejandro on X",
 };

--- a/lib/structuredData.ts
+++ b/lib/structuredData.ts
@@ -1,4 +1,10 @@
-import { config, experience, ProjectList } from "@constants/constants";
+import {
+  config,
+  experience,
+  ProjectList,
+  SITE_PROFILE_DATE_CREATED,
+  SITE_PROFILE_DATE_MODIFIED,
+} from "@constants/constants";
 import { stripHtmlToPlainText } from "@lib/plainText";
 
 const portfolioDescription =
@@ -43,6 +49,7 @@ function buildPersonNode(personUrl: string) {
     sameAs: [
       `https://github.com/${config.author.github}`,
       `https://x.com/${config.author.twitter}`,
+      "https://www.linkedin.com/in/martinezfaneyth",
     ],
   };
 }
@@ -75,6 +82,8 @@ export function generateHomepageJsonLd() {
         url: config.url,
         name: `${config.author.first_name} - Software Engineer`,
         description: config.description,
+        dateCreated: SITE_PROFILE_DATE_CREATED,
+        dateModified: SITE_PROFILE_DATE_MODIFIED,
         isPartOf: {
           "@id": websiteId,
         },
@@ -152,8 +161,10 @@ export function generateBlogJsonLd(posts: BlogPost[]) {
       mainEntityOfPage: `${config.url}/blog/posts/${post.slug}`,
       headline: post.title,
       name: post.title,
-      description:
-        stripHtmlToPlainText(post.metadata.teaser || "").substring(0, 160),
+      description: stripHtmlToPlainText(post.metadata.teaser || "").substring(
+        0,
+        160
+      ),
       datePublished: post.created_at,
       dateModified: post.created_at,
       author: {
@@ -204,8 +215,10 @@ export function generateBlogPostingJsonLd(post: BlogPost) {
     mainEntityOfPage: `${config.url}/blog/posts/${post.slug}`,
     headline: post.title,
     name: post.title,
-    description:
-      stripHtmlToPlainText(post.metadata.teaser || "").substring(0, 160),
+    description: stripHtmlToPlainText(post.metadata.teaser || "").substring(
+      0,
+      160
+    ),
     datePublished: post.created_at,
     dateModified: post.created_at,
     author: {


### PR DESCRIPTION
## Summary

Public pages now expose explicit document landmarks so parsers and assistive tech can separate navigation, primary content, and boilerplate without changing visible design.

Skip links land keyboard focus in `main` (with `tabIndex={-1}`), case studies no longer nest header/footer inside `main`, decorative wave SVGs are hidden from the accessibility tree, and homepage JSON-LD carries profile freshness dates plus LinkedIn in `sameAs`.

## Test plan

- [x] `yarn build`
- [ ] Tab to skip link on `/` and `/blog`; activate and confirm focus moves into `main`
- [ ] Inspector: `/`, `/portfolio`, one case study have sibling `header` → `main#main-content` → `footer`
- [ ] Homepage JSON-LD: `dateCreated` `2020-01-15`, `dateModified` `2026-06-22`, LinkedIn in Person `sameAs`

## QA notes

QA autofix applied: corrected `SITE_PROFILE_DATE_CREATED` to roadmap value; added `tabIndex={-1}` on all `main#main-content` targets. Residual actionable work: none. Advisory: portfolio footer social icons remain unlabeled (header-only scope per plan).

Plan: `rosey/plans/2026-06-22-seo-phase-3-semantic-plan.md`