### PR TITLE
feat(seo): add agent discovery and WebMCP interactivity

### DIFF
--- a/app/api/search-posts/route.ts
+++ b/app/api/search-posts/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { searchPosts } from "@lib/api";
 import { logError } from "@lib/logger";
 import markdownToHtml from "@lib/markdownToHtml";
+import { MAX_SEARCH_QUERY_LENGTH } from "@lib/searchQuery";
 
 export async function GET(request: NextRequest) {
   try {
@@ -13,7 +14,11 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ response: [] });
     }
 
-    const posts = await searchPosts(query.trim());
+    if (query.trim().length > MAX_SEARCH_QUERY_LENGTH) {
+      return NextResponse.json({ error: "Query too long" }, { status: 400 });
+    }
+
+    const posts = await searchPosts(query);
 
     // Process markdown teasers to HTML for consistency with blog page
     const processedPosts = await Promise.all(
@@ -32,4 +37,3 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ response: [] });
   }
 }
-

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+
+import { getAllPostsForHome } from "@lib/api";
+import { buildLlmsFull } from "@lib/llms/buildLlmsFull";
+import { logError } from "@lib/logger";
+
+export async function GET() {
+  try {
+    let posts: Awaited<ReturnType<typeof getAllPostsForHome>> = [];
+
+    try {
+      posts = (await getAllPostsForHome()) || [];
+    } catch (error) {
+      logError("llms-full-blog-posts", error);
+    }
+
+    const body = await buildLlmsFull(posts);
+
+    return new NextResponse(body, {
+      headers: {
+        "Content-Type": "text/markdown; charset=utf-8",
+        "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+        "CDN-Cache-Control":
+          "public, s-maxage=3600, stale-while-revalidate=86400",
+        "Netlify-CDN-Cache-Control":
+          "public, s-maxage=3600, stale-while-revalidate=86400",
+        "Cache-Tag": "llms-full, content",
+        "Netlify-Cache-Tag": "llms-full, content",
+        Vary: "Accept-Encoding",
+      },
+    });
+  } catch (error) {
+    logError("llms-full-txt", error);
+    return new NextResponse("Error generating llms-full.txt", { status: 500 });
+  }
+}

--- a/components/Blog/BlogSearchWrapper.tsx
+++ b/components/Blog/BlogSearchWrapper.tsx
@@ -15,6 +15,7 @@ interface BlogSearchWrapperProps {
 export default function BlogSearchWrapper({ posts }: BlogSearchWrapperProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<any[]>([]);
+  const [searchError, setSearchError] = useState<string | null>(null);
   const [isSearching, setIsSearching] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -22,18 +23,30 @@ export default function BlogSearchWrapper({ posts }: BlogSearchWrapperProps) {
     if (!query || query.trim().length === 0) {
       setSearchQuery("");
       setSearchResults([]);
+      setSearchError(null);
       setIsSearching(false);
       return;
     }
 
     setIsLoading(true);
     setSearchQuery(query);
+    setSearchError(null);
 
     try {
       const response = await fetch(
         `/api/search-posts?q=${encodeURIComponent(query)}`
       );
       const data = await response.json();
+
+      if (!response.ok) {
+        setSearchResults([]);
+        setSearchError(
+          typeof data.error === "string" ? data.error : "Search failed"
+        );
+        setIsSearching(true);
+        return;
+      }
+
       const results = data.response || [];
       setSearchResults(results);
       setIsSearching(true);
@@ -48,6 +61,7 @@ export default function BlogSearchWrapper({ posts }: BlogSearchWrapperProps) {
     } catch (error) {
       console.error("Search error:", error);
       setSearchResults([]);
+      setSearchError("Search failed");
       setIsSearching(true);
     } finally {
       setIsLoading(false);
@@ -58,6 +72,7 @@ export default function BlogSearchWrapper({ posts }: BlogSearchWrapperProps) {
     if (value.trim().length === 0) {
       setSearchQuery("");
       setSearchResults([]);
+      setSearchError(null);
       setIsSearching(false);
     }
   }, []);
@@ -110,6 +125,7 @@ export default function BlogSearchWrapper({ posts }: BlogSearchWrapperProps) {
           isLoading={isLoading}
           results={searchResults}
           isSearching={isSearching}
+          searchError={searchError}
         />
       </Section>
 

--- a/components/Blog/SearchBar.tsx
+++ b/components/Blog/SearchBar.tsx
@@ -3,6 +3,8 @@
 import SearchResultItem from "@components/Blog/SearchResultItem";
 import { AnimatePresence, motion } from "framer-motion";
 import { useEffect, useRef, useState } from "react";
+
+import { MAX_SEARCH_QUERY_LENGTH } from "@lib/searchQuery";
 import { AiOutlineClose, AiOutlineSearch } from "react-icons/ai";
 
 interface SearchBarProps {
@@ -12,7 +14,14 @@ interface SearchBarProps {
   isLoading?: boolean;
   results?: any[];
   isSearching?: boolean;
+  searchError?: string | null;
 }
+
+const searchWebMcp = {
+  toolname: "searchBlogPosts",
+  tooldescription:
+    'Read-only blog search by query string (max 128 chars). Submit the form or type to search via GET /api/search-posts?q=. Returns {"response":[...]} on success; 400 {"error":"Query too long"} when over limit.',
+} as Record<string, string>;
 
 export default function SearchBar({
   value,
@@ -21,13 +30,14 @@ export default function SearchBar({
   isLoading = false,
   results = [],
   isSearching = false,
+  searchError = null,
 }: SearchBarProps) {
   const [localValue, setLocalValue] = useState(value);
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
 
-  const [isInputFocused, setIsInputFocused] = useState(false);
-
   useEffect(() => {
+    // Keep local input in sync when parent clears search state.
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- controlled reset from BlogSearchWrapper
     setLocalValue(value);
   }, [value]);
 
@@ -66,16 +76,36 @@ export default function SearchBar({
     onSearch("");
   };
 
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+    const trimmed = localValue.trim();
+    if (trimmed.length > 0) {
+      onSearch(trimmed);
+    } else {
+      onSearch("");
+    }
+  };
+
   const hasResults = isSearching && results.length > 0;
   const showNoResults =
     isSearching &&
     results.length === 0 &&
     localValue.trim().length > 0 &&
-    !isLoading;
+    !isLoading &&
+    !searchError;
+  const showSearchError = isSearching && Boolean(searchError) && !isLoading;
 
   return (
     <div className="w-[94%] mx-auto mb-6">
-      <div className="bg-[#f0f0f0] rounded-lg overflow-hidden transition-all duration-300 shadow-[inset_0_0_0_1px_rgb(190,190,190)]">
+      <form
+        role="search"
+        className="bg-[#f0f0f0] rounded-lg overflow-hidden transition-all duration-300 shadow-[inset_0_0_0_1px_rgb(190,190,190)]"
+        onSubmit={handleSubmit}
+        {...searchWebMcp}
+      >
         <div className="relative p-4">
           <label htmlFor="blog-search" className="sr-only">
             Search blog posts
@@ -90,14 +120,18 @@ export default function SearchBar({
             </div>
             <input
               id="blog-search"
-              type="text"
+              name="q"
+              type="search"
               value={localValue}
               onChange={handleChange}
-              onFocus={() => setIsInputFocused(true)}
-              onBlur={() => setIsInputFocused(false)}
               placeholder="Search posts by title, content, or category..."
+              maxLength={MAX_SEARCH_QUERY_LENGTH}
               className="block w-full pl-12 pr-10 py-4 text-lg leading-normal font-main font-light rounded-md bg-white border-transparent focus:outline-none focus:shadow-[0_0_0_2px_rgb(0,177,106),0_0_0_6px_rgba(0,177,106,0.3)] transition-shadow duration-200"
               aria-label="Search blog posts"
+              {...({
+                toolparamdescription:
+                  "Search query for blog posts by title, content, or category (maps to GET /api/search-posts?q=).",
+              } as Record<string, string>)}
             />
             {localValue.length > 0 && (
               <button
@@ -118,7 +152,7 @@ export default function SearchBar({
         </div>
 
         <AnimatePresence>
-          {(hasResults || showNoResults) && (
+          {(hasResults || showNoResults || showSearchError) && (
             <motion.div
               initial={{ height: 0, opacity: 0 }}
               animate={{ height: "auto", opacity: 1 }}
@@ -127,6 +161,12 @@ export default function SearchBar({
               className="overflow-hidden"
             >
               <div className="px-4 pb-4">
+                {showSearchError && (
+                  <div className="text-center py-8 text-red-600 font-light text-lg">
+                    {searchError}
+                  </div>
+                )}
+
                 {showNoResults && (
                   <div className="text-center py-8 text-gray-500 font-light text-lg">
                     No posts found matching &quot;{localValue}&quot;
@@ -150,7 +190,7 @@ export default function SearchBar({
             </motion.div>
           )}
         </AnimatePresence>
-      </div>
+      </form>
     </div>
   );
 }

--- a/components/Portfolio/Contact/Contact.tsx
+++ b/components/Portfolio/Contact/Contact.tsx
@@ -18,6 +18,12 @@ import { Section } from "@components/common/Layout/Section";
 import { SectionText } from "@components/common/Layout/SectionText";
 import { SectionTitle } from "@components/common/Layout/SectionTitle";
 
+const contactWebMcp = {
+  toolname: "contactLuis",
+  tooldescription:
+    "Describes a professional inquiry form for Luis Alejandro. Human must complete reCAPTCHA and submit; agents must not submit unattended or call POST /api/contact directly.",
+} as Record<string, string>;
+
 const Contact = ({ dark }: { dark?: boolean }) => {
   const schema = yup
     .object({
@@ -117,7 +123,9 @@ const Contact = ({ dark }: { dark?: boolean }) => {
         </SectionText>
         <form
           className="w-full lg:max-w-[80%] mx-auto relative mb-5 p-8 lg:p-0"
+          // eslint-disable-next-line react-hooks/refs -- react-hook-form submit handler factory
           onSubmit={handleSubmit(onSubmit)}
+          {...contactWebMcp}
         >
           <div className="flex flex-col lg:flex-row">
             <div className="flex flex-col mx-0 lg:w-4/12 lg:mx-4">
@@ -132,6 +140,10 @@ const Contact = ({ dark }: { dark?: boolean }) => {
                 id="contactName"
                 className="block my-1 px-3 py-1.5 w-full rounded-xl bg-white border-transparent text-lg leading-normal font-main font-light focus:bg-white focus:ring-2 focus:ring-neutral-300 focus:border-neutral-400"
                 {...register("contactName")}
+                {...({
+                  toolparamdescription:
+                    "Full name of the sender or hiring manager (3-256 characters).",
+                } as Record<string, string>)}
               />
 
               <p className="block mx-1 h-6 text-sm leading-normal font-main font-normal text-red-500">
@@ -149,6 +161,10 @@ const Contact = ({ dark }: { dark?: boolean }) => {
                 id="contactEmail"
                 className="block my-1 px-3 py-1.5 w-full rounded-xl bg-white border-transparent text-lg leading-normal font-main font-light focus:bg-white focus:ring-2 focus:ring-neutral-300 focus:border-neutral-400"
                 {...register("contactEmail")}
+                {...({
+                  toolparamdescription:
+                    "Valid email address where Luis Alejandro should reply.",
+                } as Record<string, string>)}
               />
 
               <p className="block mx-1 h-6 text-sm leading-normal font-main font-normal text-red-500">
@@ -180,6 +196,10 @@ const Contact = ({ dark }: { dark?: boolean }) => {
                 id="contactMessage"
                 className="block my-1 px-3 py-1.5 w-full h-40 rounded-xl bg-white border-transparent text-lg leading-normal font-main font-light focus:bg-white focus:ring-2 focus:ring-neutral-300 focus:border-neutral-400 resize-none"
                 {...register("contactMessage")}
+                {...({
+                  toolparamdescription:
+                    "Contract description, job details, or inquiry text (3-1024 characters).",
+                } as Record<string, string>)}
               ></textarea>
 
               <p className="block mx-1 h-6 text-sm leading-normal font-main font-normal text-red-500">

--- a/content/llms/README.md
+++ b/content/llms/README.md
@@ -1,0 +1,5 @@
+# llms-full corpus sections
+
+Markdown in this folder feeds `/llms-full.txt` via `lib/llms/buildLlmsFull.ts`.
+
+When homepage, portfolio, or contact copy changes in React components, update the matching `.md` file here so the AI corpus stays aligned. Phase 5 per-route markdown twins may replace this maintenance model later.

--- a/content/llms/contact.md
+++ b/content/llms/contact.md
@@ -1,0 +1,5 @@
+The contact page is the professional inquiry surface for hiring conversations, contract proposals, and project discussions.
+
+Visitors can send a message with their name, email, and inquiry text. Submission requires completing reCAPTCHA and is intended for human-mediated use—automated agents should not submit forms without explicit human confirmation.
+
+Luis replies to serious contract and full-time remote inquiries within a few business days.

--- a/content/llms/home.md
+++ b/content/llms/home.md
@@ -1,0 +1,5 @@
+Luis Alejandro Martinez Faneyth is a Venezuelan full-stack software engineer who has worked remotely for more than a decade. He builds production systems for SaaS and distributed-product teams, with a focus on TypeScript, Python, and Go.
+
+His work centers on clear async communication, explicit ownership, and shipping maintainable APIs and services that stay dependable after launch. Typical engagements include backend architecture, third-party integrations, CI/CD hardening, and rescuing legacy systems without a big-bang rewrite.
+
+With 16+ years of professional experience, he treats remote collaboration as the default operating mode—not a compromise. Clients get consistent delivery, documented decisions, and maintainable codebases the next engineer can pick up without archaeology.

--- a/content/llms/portfolio.md
+++ b/content/llms/portfolio.md
@@ -1,0 +1,7 @@
+The portfolio presents Luis Alejandro's professional background: skills, work history, open-source projects, and selected case studies.
+
+Notable impact includes Dockershelf (294K+ downloads of lean Docker images), a 39% booking increase from Expedia API integration for Wheel the World, and 60+ open-source projects on GitHub.
+
+Case studies cover accessible travel platforms, CI/CD optimization, desktop diagnostics (Electron/Ionic), Docker tooling, and public-sector GNU/Linux distribution work.
+
+The portfolio page also links to the contact form for contract and full-time remote inquiries.

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2,6 +2,7 @@ import { createBucketClient } from "@cosmicjs/sdk";
 
 import { ENV_NAME } from "@constants/constants";
 import { logError } from "@lib/logger";
+import { sanitizeSearchQuery } from "@lib/searchQuery";
 
 const BUCKET_SLUG = process.env.COSMIC_BUCKET_SLUG;
 
@@ -300,78 +301,66 @@ export async function getCategoryDetails(categorySlug: any) {
 
 export async function searchPosts(query: string) {
   try {
-    if (!query || query.trim().length === 0) {
+    const searchQuery = sanitizeSearchQuery(query);
+
+    if (!searchQuery) {
       return [];
     }
 
-    const searchQuery = query.trim();
     const regexPattern = { $regex: searchQuery, $options: "i" };
+    const statusFilter =
+      ENV_NAME !== "local" ? "published" : { $in: ["published", "draft"] };
+    const postProps = [
+      "id",
+      "slug",
+      "title",
+      "metadata.hero",
+      "metadata.categories",
+      "metadata.teaser",
+      "created_at",
+    ];
 
     const data = await cosmic.objects
       .find({
         type: "posts",
-        status:
-          ENV_NAME !== "local" ? "published" : { $in: ["published", "draft"] },
+        status: statusFilter,
         $or: [{ title: regexPattern }, { "metadata.teaser": regexPattern }],
       })
-      .props([
-        "id",
-        "slug",
-        "title",
-        "metadata.hero",
-        "metadata.categories",
-        "metadata.teaser",
-        "created_at",
-      ])
+      .props(postProps)
       .sort("-created_at");
 
-    // Filter by category names (title and teaser already filtered by Cosmic query)
     const posts = data?.objects || [];
-    const searchQueryLower = searchQuery.toLowerCase();
+    const existingPostIds = new Set(posts.map((p: any) => p.id));
 
-    // Also search for posts matching categories
-    // Note: This requires fetching all posts to check categories, which is less efficient
-    // but necessary since Cosmic.js doesn't support nested field search in categories
-    const allPostsData = await cosmic.objects
+    const categoryData = await cosmic.objects
+      .find({
+        type: "categories",
+        title: regexPattern,
+      })
+      .props(["id"]);
+
+    const matchingCategoryIds = (categoryData?.objects || []).map(
+      (category: any) => category.id
+    );
+
+    if (matchingCategoryIds.length === 0) {
+      return posts;
+    }
+
+    const categoryPostsData = await cosmic.objects
       .find({
         type: "posts",
-        status:
-          ENV_NAME !== "local" ? "published" : { $in: ["published", "draft"] },
+        status: statusFilter,
+        "metadata.categories": { $in: matchingCategoryIds },
       })
-      .props([
-        "id",
-        "slug",
-        "title",
-        "metadata.hero",
-        "metadata.categories",
-        "metadata.teaser",
-        "created_at",
-      ])
+      .props(postProps)
       .sort("-created_at");
 
-    // Find posts that match categories but weren't already found by title/teaser search
-    const existingPostIds = new Set(posts.map((p: any) => p.id));
-    const categoryMatches = (allPostsData?.objects || []).filter(
-      (post: any) => {
-        // Skip if already found by title/teaser search
-        if (existingPostIds.has(post.id)) return false;
-
-        // Check if query matches any category title
-        return (
-          post.metadata?.categories?.some((cat: any) =>
-            cat.title?.toLowerCase().includes(searchQueryLower)
-          ) || false
-        );
-      }
+    const categoryMatches = (categoryPostsData?.objects || []).filter(
+      (post: any) => !existingPostIds.has(post.id)
     );
 
-    // Combine results and deduplicate
-    const allResults = [...posts, ...categoryMatches];
-    const uniqueResults = allResults.filter(
-      (post, index, self) => index === self.findIndex((p) => p.id === post.id)
-    );
-
-    return uniqueResults;
+    return [...posts, ...categoryMatches];
   } catch (error) {
     logError("searchPosts", error, {
       query,

--- a/lib/llms/buildLlmsFull.ts
+++ b/lib/llms/buildLlmsFull.ts
@@ -1,0 +1,77 @@
+import fs from "fs";
+import path from "path";
+
+import { canonicalHostnameUrl } from "@constants/constants";
+import markdownToHtml from "@lib/markdownToHtml";
+import { stripHtmlToPlainText } from "@lib/plainText";
+
+export type LlmsFullPost = {
+  slug: string;
+  title: string;
+  created_at?: string;
+  metadata?: { teaser?: string };
+};
+
+function readSection(filename: string): string {
+  const filePath = path.join(process.cwd(), "content/llms", filename);
+  try {
+    return fs.readFileSync(filePath, "utf-8").trim();
+  } catch {
+    return `_Section content unavailable (${filename})._`;
+  }
+}
+
+function formatSection(title: string, url: string, body: string): string {
+  return `# ${title}\n\nCanonical URL: ${url}\n\n${body}`;
+}
+
+async function formatBlogSection(posts: LlmsFullPost[]): Promise<string> {
+  const lines = await Promise.all(
+    posts.map(async (post) => {
+      const url = `${canonicalHostnameUrl}/blog/posts/${post.slug}`;
+      const rawTeaser = post.metadata?.teaser || "";
+      const teaserHtml = rawTeaser.startsWith("<")
+        ? rawTeaser
+        : await markdownToHtml(rawTeaser);
+      const teaser = stripHtmlToPlainText(teaserHtml).trim();
+      let date = "";
+      if (post.created_at) {
+        const parsed = new Date(post.created_at);
+        if (!Number.isNaN(parsed.getTime())) {
+          date = parsed.toISOString().split("T")[0];
+        }
+      }
+      const heading = `### [${post.title}](${url})${date ? ` — ${date}` : ""}`;
+      return teaser ? `${heading}\n\n${teaser}` : heading;
+    })
+  );
+
+  return formatSection(
+    "Blog Index",
+    `${canonicalHostnameUrl}/blog`,
+    lines.join("\n\n") || "_No posts available._"
+  );
+}
+
+export async function buildLlmsFull(
+  posts: LlmsFullPost[] = []
+): Promise<string> {
+  const sections = [
+    formatSection("Home", `${canonicalHostnameUrl}/`, readSection("home.md")),
+    formatSection(
+      "Portfolio",
+      `${canonicalHostnameUrl}/portfolio`,
+      readSection("portfolio.md")
+    ),
+    await formatBlogSection(posts),
+    formatSection(
+      "Contact",
+      `${canonicalHostnameUrl}/contact`,
+      readSection("contact.md")
+    ),
+  ];
+
+  const generatedAt = new Date().toISOString();
+
+  return `${sections.join("\n\n---\n\n")}\n\n---\n\n## Generated\n\nSnapshot generated at: ${generatedAt}\n`;
+}

--- a/lib/searchQuery.ts
+++ b/lib/searchQuery.ts
@@ -1,0 +1,11 @@
+export const MAX_SEARCH_QUERY_LENGTH = 128;
+
+export function sanitizeSearchQuery(query: string): string | null {
+  const trimmed = query.trim();
+
+  if (!trimmed || trimmed.length > MAX_SEARCH_QUERY_LENGTH) {
+    return null;
+  }
+
+  return trimmed.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -177,6 +177,15 @@ const config: NextConfig = {
           },
         ],
       },
+      {
+        source: "/(.*)",
+        headers: [
+          {
+            key: "Link",
+            value: '</llms.txt>; rel="describedby"; type="text/markdown"',
+          },
+        ],
+      },
     ];
   },
   experimental: {

--- a/public/.well-known/agent-permissions.json
+++ b/public/.well-known/agent-permissions.json
@@ -80,6 +80,16 @@
       "description": "Curated AI-readable site index."
     },
     {
+      "type": "llms_full",
+      "endpoint": "https://luisalejandro.org/llms-full.txt",
+      "description": "Single-request markdown snapshot of primary site surfaces."
+    },
+    {
+      "type": "search_posts",
+      "endpoint": "https://luisalejandro.org/api/search-posts",
+      "description": "Read-only blog post search by query string (GET ?q=, max 128 characters). Returns 400 {\"error\":\"Query too long\"} when q exceeds the limit; empty q returns {\"response\":[]}."
+    },
+    {
       "type": "sitemap",
       "endpoint": "https://luisalejandro.org/sitemap.xml",
       "description": "Canonical XML sitemap."

--- a/public/agents.md
+++ b/public/agents.md
@@ -11,6 +11,7 @@ luisalejandro.org is the personal website, portfolio, and technical blog of Luis
 Use these sources before broad crawling:
 
 - `https://luisalejandro.org/llms.txt` for a concise AI-oriented index.
+- `https://luisalejandro.org/llms-full.txt` for a single-request markdown snapshot of primary surfaces.
 - `https://luisalejandro.org/sitemap.xml` for canonical URLs.
 - `https://luisalejandro.org/blog/posts/feed.xml` for the blog RSS feed.
 - `https://luisalejandro.org/blog/posts/feed.json` for the JSON feed.
@@ -39,6 +40,7 @@ Suggested citation format:
 ## Interaction Guidance
 
 - Reading and following public links is allowed.
+- Blog search is read-only via `GET /api/search-posts?q=` or the `/blog` search UI. Query strings are capped at 128 characters; longer queries return HTTP 400 with `{"error":"Query too long"}`. Success responses use `{"response":[...]}`; empty or whitespace `q` returns `{"response":[]}`.
 - Submitting contact forms or other forms should require explicit human confirmation.
 - Do not attempt login, token, license, or private API workflows unless the user explicitly asks and provides the needed context.
 - Prefer public feeds and API-safe endpoints over repeated page scraping when collecting blog metadata.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,31 +1,51 @@
 # Luis Alejandro
-> Personal website, portfolio, and software engineering blog for Luis Alejandro Martinez Faneyth, a Venezuelan full stack software engineer, open source contributor, and remote developer.
+
+> Luis Alejandro Martinez Faneyth is a remote full-stack software engineer with 16+ years of distributed systems expertise, specializing in TypeScript, Python, and Go.
 
 This file is the preferred starting point for AI assistants, answer engines, and crawlers that need concise context about luisalejandro.org.
 
+## Key Information
+
+- Caracas-born developer focusing on robust, minimalist architecture and remote collaboration.
+- Author of open-source packages with 294K+ Dockershelf downloads and 60+ public GitHub projects.
+- Tech stack: Node.js, Next.js, Django, FastAPI, Go, Docker, and Tailwind CSS.
+
+## Main Resources
+
+- [Professional Blog](https://luisalejandro.org/blog) — Articles on modern systems engineering and software architecture.
+- [Portfolio & Open Source Work](https://luisalejandro.org/portfolio) — Skills, case studies, selected projects, and contact entry point.
+- [Contact & Hire](https://luisalejandro.org/contact) — Contact form and business inquiry surface for remote contracts.
+- [Full Corpus (llms-full.txt)](https://luisalejandro.org/llms-full.txt) — Single-request markdown snapshot of primary site surfaces.
+
 ## Canonical Site Sections
-- Home: https://luisalejandro.org/ - Short biography, professional positioning, and primary navigation.
-- Portfolio: https://luisalejandro.org/portfolio - Skills, work history, case studies, selected projects, and contact entry point.
-- Blog: https://luisalejandro.org/blog - Technical posts about software development, open source, remote work, and engineering lessons.
-- Contact: https://luisalejandro.org/contact - Contact surface for professional inquiries.
+
+- Home: https://luisalejandro.org/ — Biography, professional positioning, and primary navigation.
+- Portfolio: https://luisalejandro.org/portfolio — Skills, work history, case studies, and projects.
+- Blog: https://luisalejandro.org/blog — Technical posts about software development and engineering lessons.
+- Contact: https://luisalejandro.org/contact — Professional inquiries and hiring conversations.
 
 ## Case Studies
-- Expedia API Integration: https://luisalejandro.org/case-studies/expedia - Booking engine integration work for Wheel The World.
-- Wheel The World CI/CD: https://luisalejandro.org/case-studies/wheeltheworld - CI/CD reliability and cost optimization work.
-- Soleit Desktop App: https://luisalejandro.org/case-studies/soleit - Electron and Ionic React diagnostic desktop application.
-- Dockershelf: https://luisalejandro.org/case-studies/dockershelf - Lightweight Docker image catalog and automation.
-- Canaima GNU/Linux: https://luisalejandro.org/case-studies/canaima - Linux distribution and public-sector free software work.
+
+- Expedia API Integration: https://luisalejandro.org/case-studies/expedia — Booking engine integration work for Wheel The World.
+- Wheel The World CI/CD: https://luisalejandro.org/case-studies/wheeltheworld — CI/CD reliability and cost optimization work.
+- Soleit Desktop App: https://luisalejandro.org/case-studies/soleit — Electron and Ionic React diagnostic desktop application.
+- Dockershelf: https://luisalejandro.org/case-studies/dockershelf — Lightweight Docker image catalog and automation.
+- Canaima GNU/Linux: https://luisalejandro.org/case-studies/canaima — Linux distribution and public-sector free software work.
 
 ## Machine-Readable Discovery
+
+- Full corpus: https://luisalejandro.org/llms-full.txt
 - XML sitemap: https://luisalejandro.org/sitemap.xml
 - RSS feed: https://luisalejandro.org/blog/posts/feed.xml
 - Atom feed: https://luisalejandro.org/blog/posts/atom.xml
 - JSON feed: https://luisalejandro.org/blog/posts/feed.json
 - Robots policy: https://luisalejandro.org/robots.txt
 - AI attribution policy: https://luisalejandro.org/ai.txt
+- Agent instructions: https://luisalejandro.org/agents.md
 - Agent permissions: https://luisalejandro.org/.well-known/agent-permissions.json
 
 ## Content Use Guidance
+
 - Prefer canonical URLs from this file and the XML sitemap when citing the site.
 - Use blog post pages as sources for technical claims.
 - Use portfolio and case study pages as sources for professional background.


### PR DESCRIPTION
## Summary

AI agents and answer engines can now discover luisalejandro.org in one pass: a refreshed `llms.txt` index, a dynamic `llms-full.txt` markdown corpus, site-wide `Link` headers pointing at the index, and WebMCP annotations on the contact form and blog search. Human UX is unchanged — contact still requires reCAPTCHA and explicit human submission.

Blog search is hardened for programmatic use (128-character cap, regex escaping, clearer error responses) and category matching no longer scans the full post bucket on every query.

## What changed

| Surface | Behavior |
| --- | --- |
| `/llms-full.txt` | Single-request snapshot of home, portfolio, blog index, and contact sections with a generated timestamp; CDN-cached 1h |
| `Link` header | Every Next-handled route advertises `</llms.txt>; rel="describedby"` |
| WebMCP | `contactLuis` and `searchBlogPosts` tools with field-level `toolparamdescription` |
| Policy | `agents.md` and `agent-permissions.json` document `llms-full` and search API contracts |
| Search | Category matches via targeted Cosmic queries instead of a second full-bucket fetch |

## Test plan

- [ ] `curl -sI https://localhost:3101/ \| grep -i link` — `describedby` points at `llms.txt`
- [ ] `curl -s https://localhost:3101/llms-full.txt` — four sections + `Generated` timestamp
- [ ] `/blog` — search returns results; over-128-char query shows validation error (not "No posts found")
- [ ] `/contact` and `/blog` — inspect DOM for `toolname` / `tooldescription` / `toolparamdescription`
- [ ] `yarn type-check` and `yarn build`

Plan: `rosey/plans/2026-06-23-seo-phase-4-agent-interactivity.md`

---

![Composer](https://img.shields.io/badge/Composer_2.5-000000)