### PR TITLE
feat(seo): add markdown twins and AI crawl policy

### DIFF
--- a/app/.well-known/api-catalog/route.ts
+++ b/app/.well-known/api-catalog/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+import { canonicalHostnameUrl } from "@constants/constants";
+import { logError } from "@lib/logger";
+
+const catalogLinkset = {
+  linkset: [
+    {
+      anchor: canonicalHostnameUrl,
+      "service-doc": [
+        { href: `${canonicalHostnameUrl}/llms.txt` },
+        { href: `${canonicalHostnameUrl}/llms-full.txt` },
+        { href: `${canonicalHostnameUrl}/.well-known/agent-permissions.json` },
+        { href: `${canonicalHostnameUrl}/sitemap.xml` },
+      ],
+      item: [{ href: `${canonicalHostnameUrl}/blog/posts/feed.xml` }],
+    },
+  ],
+};
+
+export async function GET() {
+  try {
+    return NextResponse.json(catalogLinkset, {
+      headers: {
+        "Content-Type": "application/linkset+json",
+        "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+        "CDN-Cache-Control":
+          "public, s-maxage=3600, stale-while-revalidate=86400",
+        "Netlify-CDN-Cache-Control":
+          "public, s-maxage=3600, stale-while-revalidate=86400",
+        "Cache-Tag": "api-catalog, content",
+        "Netlify-Cache-Tag": "api-catalog, content",
+        Vary: "Accept-Encoding",
+      },
+    });
+  } catch (error) {
+    logError("api-catalog", error);
+    return new NextResponse("Error generating API catalog", { status: 500 });
+  }
+}

--- a/app/blog/category/[slug]/page.tsx
+++ b/app/blog/category/[slug]/page.tsx
@@ -1,5 +1,7 @@
+import { Metadata } from "next";
 import { notFound } from "next/navigation";
 
+import { config } from "@constants/constants";
 import { getAllPostsForCategory } from "@lib/api";
 import { logError } from "@lib/logger";
 
@@ -15,6 +17,25 @@ interface CategoryPageProps {
   params: Promise<{
     slug: string;
   }>;
+}
+
+export async function generateMetadata({
+  params,
+}: CategoryPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  return {
+    alternates: {
+      canonical: `${config.url}/blog/category/${slug}`,
+      types: {
+        "text/markdown": [
+          {
+            url: `/blog/category/${slug}.md`,
+            title: "Markdown twin",
+          },
+        ],
+      },
+    },
+  };
 }
 
 export default async function CategoryPage({ params }: CategoryPageProps) {

--- a/app/blog/category/page.tsx
+++ b/app/blog/category/page.tsx
@@ -64,6 +64,14 @@ export const metadata: Metadata = {
   },
   alternates: {
     canonical: `${config.url}/blog/category`,
+    types: {
+      "text/markdown": [
+        {
+          url: "/blog/category.md",
+          title: "Markdown twin",
+        },
+      ],
+    },
   },
 };
 

--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -140,6 +140,12 @@ export const metadata: Metadata = {
           title: "Sitemap",
         },
       ],
+      "text/markdown": [
+        {
+          url: "/blog.md",
+          title: "Markdown twin",
+        },
+      ],
     },
   },
   other: {

--- a/app/blog/posts/[slug]/layout.tsx
+++ b/app/blog/posts/[slug]/layout.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from "next";
 
 import { ADSENSE_PUBLISHER_ID, config } from "@constants/constants";
-import { getPostAndMorePosts } from "@lib/api";
+import { getPostAndMorePosts, getPublishedPostForTwin } from "@lib/api";
 import { stripHtmlToPlainText } from "@lib/plainText";
 
 import "@styles/tailwind.css";
@@ -93,6 +93,45 @@ export async function generateMetadata({
   // Generate article schema-friendly publication date
   const publishedDate = new Date(post.created_at);
   const publishedISO = publishedDate.toISOString();
+
+  const publishedTwin = await getPublishedPostForTwin(slug);
+
+  const feedAlternates = {
+    "application/rss+xml": [
+      {
+        url: `${config.url}/blog/posts/feed.xml`,
+        title: "Luis Alejandro Blog RSS Feed",
+      },
+    ],
+    "application/atom+xml": [
+      {
+        url: `${config.url}/blog/posts/atom.xml`,
+        title: "Luis Alejandro Blog Atom Feed",
+      },
+    ],
+    "application/feed+json": [
+      {
+        url: `${config.url}/blog/posts/feed.json`,
+        title: "Luis Alejandro Blog JSON Feed",
+      },
+    ],
+    "application/xml": [
+      {
+        url: `${config.url}/sitemap.xml`,
+        title: "Sitemap",
+      },
+    ],
+    ...(publishedTwin
+      ? {
+          "text/markdown": [
+            {
+              url: `/blog/posts/${slug}.md`,
+              title: "Markdown twin",
+            },
+          ],
+        }
+      : {}),
+  };
 
   return {
     title: seoTitle,
@@ -199,32 +238,7 @@ export async function generateMetadata({
     manifest: `${config.url}/favicon/site.webmanifest`,
     alternates: {
       canonical: canonicalUrl,
-      types: {
-        "application/rss+xml": [
-          {
-            url: `${config.url}/blog/posts/feed.xml`,
-            title: "Luis Alejandro Blog RSS Feed",
-          },
-        ],
-        "application/atom+xml": [
-          {
-            url: `${config.url}/blog/posts/atom.xml`,
-            title: "Luis Alejandro Blog Atom Feed",
-          },
-        ],
-        "application/feed+json": [
-          {
-            url: `${config.url}/blog/posts/feed.json`,
-            title: "Luis Alejandro Blog JSON Feed",
-          },
-        ],
-        "application/xml": [
-          {
-            url: `${config.url}/sitemap.xml`,
-            title: "Sitemap",
-          },
-        ],
-      },
+      types: feedAlternates,
     },
     other: {
       // Google AdSense verification

--- a/app/case-studies/canaima/layout.tsx
+++ b/app/case-studies/canaima/layout.tsx
@@ -47,6 +47,13 @@ export const metadata: Metadata = {
     creator: "@LuisDevelops",
     images: [`${config.url}/images/case-studies/canaima-hero.jpg`],
   },
+  alternates: {
+    types: {
+      "text/markdown": [
+        { url: "/case-studies/canaima.md", title: "Markdown twin" },
+      ],
+    },
+  },
   other: {
     // Sitemap reference
     sitemap: `${config.url}/sitemap.xml`,

--- a/app/case-studies/dockershelf/layout.tsx
+++ b/app/case-studies/dockershelf/layout.tsx
@@ -46,6 +46,16 @@ export const metadata: Metadata = {
     creator: "@LuisDevelops",
     images: [`${config.url}/images/case-studies/dockershelf-hero.png`],
   },
+  alternates: {
+    types: {
+      "text/markdown": [
+        {
+          url: "/case-studies/dockershelf.md",
+          title: "Markdown twin",
+        },
+      ],
+    },
+  },
   other: {
     // Sitemap reference
     sitemap: `${config.url}/sitemap.xml`,

--- a/app/case-studies/expedia/layout.tsx
+++ b/app/case-studies/expedia/layout.tsx
@@ -46,6 +46,13 @@ export const metadata: Metadata = {
     creator: "@LuisDevelops",
     images: [`${config.url}/images/case-studies/expedia-hero.png`],
   },
+  alternates: {
+    types: {
+      "text/markdown": [
+        { url: "/case-studies/expedia.md", title: "Markdown twin" },
+      ],
+    },
+  },
   other: {
     // Sitemap reference
     sitemap: `${config.url}/sitemap.xml`,

--- a/app/case-studies/soleit/layout.tsx
+++ b/app/case-studies/soleit/layout.tsx
@@ -48,6 +48,13 @@ export const metadata: Metadata = {
     creator: "@LuisDevelops",
     images: [`${config.url}/images/case-studies/soleit-hero.png`],
   },
+  alternates: {
+    types: {
+      "text/markdown": [
+        { url: "/case-studies/soleit.md", title: "Markdown twin" },
+      ],
+    },
+  },
   other: {
     // Sitemap reference
     sitemap: `${config.url}/sitemap.xml`,

--- a/app/case-studies/wheeltheworld/layout.tsx
+++ b/app/case-studies/wheeltheworld/layout.tsx
@@ -46,6 +46,13 @@ export const metadata: Metadata = {
     creator: "@LuisDevelops",
     images: [`${config.url}/images/case-studies/wheeltheworld-hero.png`],
   },
+  alternates: {
+    types: {
+      "text/markdown": [
+        { url: "/case-studies/wheeltheworld.md", title: "Markdown twin" },
+      ],
+    },
+  },
   other: {
     // Sitemap reference
     sitemap: `${config.url}/sitemap.xml`,

--- a/app/contact/layout.tsx
+++ b/app/contact/layout.tsx
@@ -1,0 +1,22 @@
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  alternates: {
+    types: {
+      "text/markdown": [
+        {
+          url: "/contact.md",
+          title: "Markdown twin",
+        },
+      ],
+    },
+  },
+};
+
+export default function ContactLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/markdown-twin/[[...path]]/route.ts
+++ b/app/markdown-twin/[[...path]]/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+import { logError } from "@lib/logger";
+import { resolveTwinMarkdown } from "@lib/markdown/resolveTwin";
+import { twinMarkdownHeaders } from "@lib/markdown/twinHeaders";
+
+type RouteContext = {
+  params: Promise<{ path?: string[] }>;
+};
+
+export async function GET(_request: Request, context: RouteContext) {
+  try {
+    const { path = [] } = await context.params;
+    const body = await resolveTwinMarkdown(path);
+
+    if (!body) {
+      return new NextResponse("Not found", { status: 404 });
+    }
+
+    return new NextResponse(body, { headers: twinMarkdownHeaders });
+  } catch (error) {
+    logError("markdown-twin", error);
+    return new NextResponse("Error generating markdown twin", { status: 500 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -15,6 +16,19 @@ import ButtonBar from "@components/Home/ButtonBar";
 import { HomeContentSections } from "@components/Home/HomeContentSections";
 
 import Gallery from "@side-effects/Home/Gallery";
+
+export const metadata: Metadata = {
+  alternates: {
+    types: {
+      "text/markdown": [
+        {
+          url: "/index.md",
+          title: "Markdown twin",
+        },
+      ],
+    },
+  },
+};
 
 export default async function HomePage() {
   const homepageJsonLd = generateHomepageJsonLd();

--- a/app/portfolio/layout.tsx
+++ b/app/portfolio/layout.tsx
@@ -137,6 +137,12 @@ export const metadata: Metadata = {
           title: "Sitemap",
         },
       ],
+      "text/markdown": [
+        {
+          url: "/portfolio.md",
+          title: "Markdown twin",
+        },
+      ],
     },
   },
   other: {

--- a/app/robots.txt/route.ts
+++ b/app/robots.txt/route.ts
@@ -3,43 +3,26 @@ import { NextResponse } from "next/server";
 import { canonicalHostnameUrl } from "@constants/constants";
 import { logError } from "@lib/logger";
 
+const CONTENT_SIGNAL = "Content-Signal: search=yes, ai-input=yes, ai-train=no";
+
+function aiCrawlerBlock(userAgent: string): string {
+  return `User-agent: ${userAgent}
+Allow: /
+${CONTENT_SIGNAL}
+`;
+}
+
 export async function GET() {
   try {
     const robotsTemplate = `# *
 User-agent: *
 Allow: /
 
+# Declare usage boundaries for real-time models versus model pre-training
+${CONTENT_SIGNAL}
+
 # AI crawlers and answer engines
-User-agent: GPTBot
-Allow: /
-
-User-agent: OAI-SearchBot
-Allow: /
-
-User-agent: ChatGPT-User
-Allow: /
-
-User-agent: ClaudeBot
-Allow: /
-
-User-agent: Claude-Web
-Allow: /
-
-User-agent: PerplexityBot
-Allow: /
-
-User-agent: Perplexity-User
-Allow: /
-
-User-agent: Google-Extended
-Allow: /
-
-User-agent: Applebot
-Allow: /
-
-User-agent: Applebot-Extended
-Allow: /
-
+${aiCrawlerBlock("GPTBot")}${aiCrawlerBlock("OAI-SearchBot")}${aiCrawlerBlock("ChatGPT-User")}${aiCrawlerBlock("ClaudeBot")}${aiCrawlerBlock("Claude-Web")}${aiCrawlerBlock("PerplexityBot")}${aiCrawlerBlock("Perplexity-User")}${aiCrawlerBlock("Google-Extended")}${aiCrawlerBlock("Applebot")}${aiCrawlerBlock("Applebot-Extended")}
 # Host
 Host: ${canonicalHostnameUrl}
 

--- a/content/case-studies/README.md
+++ b/content/case-studies/README.md
@@ -1,0 +1,5 @@
+# Case study markdown twins
+
+Hand-authored markdown mirrors the narrative on each case study page. Update these files when case study copy changes on the React pages.
+
+Twins are served at `/case-studies/{slug}.md` and linked from HTML via `rel="alternate" type="text/markdown"`.

--- a/content/case-studies/canaima.md
+++ b/content/case-studies/canaima.md
@@ -1,0 +1,15 @@
+# Canaima GNU/Linux
+
+Linux distribution and public-sector free software work reaching hundreds of thousands of users.
+
+## Challenge
+
+Deliver a Venezuelan GNU/Linux distribution suitable for education and public institutions with sustainable packaging and release practices.
+
+## Approach
+
+Contributed to distribution engineering, community packaging, and tooling that supports national-scale deployment.
+
+## Results
+
+Canaima has reached 220K+ users, advancing free software adoption in public-sector and educational contexts.

--- a/content/case-studies/dockershelf.md
+++ b/content/case-studies/dockershelf.md
@@ -1,0 +1,15 @@
+# Dockershelf
+
+Dockershelf is a repository that serves as a collector for docker recipes that are universal, efficient and slim. Shelves hold different versions of popular languages or applications. Images are updated, tested and published weekly via a GitHub Actions workflow.
+
+## Challenge
+
+Developers need dependable, slim base images across Python, Node, Debian, and LaTeX stacks without maintaining one-off Dockerfiles in every project.
+
+## Approach
+
+Dockershelf automates image builds, publishes versioned shelves, and optimizes image size compared with many official images.
+
+## Results
+
+The catalog has grown to 294K+ downloads with images often several times smaller than official equivalents, supporting CI/CD and local development workflows.

--- a/content/case-studies/expedia.md
+++ b/content/case-studies/expedia.md
@@ -1,0 +1,15 @@
+# Expedia API Integration
+
+Case study for Wheel The World: integrating Expedia's booking APIs into a travel platform that serves travelers with accessibility needs.
+
+## Challenge
+
+Connect hotel inventory and booking flows to Expedia's partner APIs while keeping latency and error handling production-grade for a high-traffic consumer product.
+
+## Approach
+
+Designed API integration layers, caching, and booking orchestration aligned with Wheel The World's product requirements.
+
+## Results
+
+Contributed to measurable booking conversion improvements (39% booking boost cited in portfolio materials) through reliable Expedia-powered search and checkout paths.

--- a/content/case-studies/soleit.md
+++ b/content/case-studies/soleit.md
@@ -1,0 +1,15 @@
+# Soleit Desktop App
+
+Electron and Ionic React diagnostic desktop application for field technicians.
+
+## Challenge
+
+Technicians needed an offline-capable desktop tool to run hardware diagnostics with a consistent UX across operating systems.
+
+## Approach
+
+Delivered a cross-platform Electron shell with Ionic React UI components and structured diagnostic workflows.
+
+## Results
+
+A maintainable desktop product that supports technicians in the field with a modern, branded interface.

--- a/content/case-studies/wheeltheworld.md
+++ b/content/case-studies/wheeltheworld.md
@@ -1,0 +1,15 @@
+# Wheel The World CI/CD
+
+CI/CD reliability and cost optimization work for Wheel The World's engineering organization.
+
+## Challenge
+
+Pipeline instability and cloud spend were slowing releases for a distributed product team serving travelers worldwide.
+
+## Approach
+
+Hardened deployment pipelines, improved observability, and tuned infrastructure usage without sacrificing release velocity.
+
+## Results
+
+More dependable releases and reduced operational toil, enabling the team to ship product changes with greater confidence.

--- a/content/llms/README.md
+++ b/content/llms/README.md
@@ -1,5 +1,5 @@
 # llms-full corpus sections
 
-Markdown in this folder feeds `/llms-full.txt` via `lib/llms/buildLlmsFull.ts`.
+Markdown in this folder feeds `/llms-full.txt` and per-route markdown twins via `lib/markdown/`.
 
-When homepage, portfolio, or contact copy changes in React components, update the matching `.md` file here so the AI corpus stays aligned. Phase 5 per-route markdown twins may replace this maintenance model later.
+When homepage, portfolio, or contact copy changes in React components, update the matching `.md` file here so the AI corpus and twins stay aligned. Case study twins live in `content/case-studies/`.

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -164,6 +164,126 @@ export async function getMorePosts(slug: any) {
   }
 }
 
+/** Published-only post fetch for markdown twins (ignores local draft ENV). */
+export async function getPublishedPostForTwin(slug: string) {
+  if (!hasCosmicCredentials()) {
+    return undefined;
+  }
+  try {
+    const object = await cosmic.objects
+      .find({
+        type: "posts",
+        slug,
+        status: "published",
+      })
+      .props([
+        "title",
+        "slug",
+        "metadata.content",
+        "metadata.categories",
+        "created_at",
+      ]);
+    return object?.objects?.length ? object.objects[0] : undefined;
+  } catch (error) {
+    if (is404(error)) {
+      return undefined;
+    }
+    logError("getPublishedPostForTwin", error, { slug });
+    return undefined;
+  }
+}
+
+/** Published-only home listing for markdown twins (ignores local draft ENV). */
+export async function getPublishedPostsForHomeTwin() {
+  if (!hasCosmicCredentials()) {
+    return [];
+  }
+  try {
+    const data = await cosmic.objects
+      .find({
+        type: "posts",
+        status: "published",
+      })
+      .props([
+        "id",
+        "slug",
+        "title",
+        "metadata.hero",
+        "metadata.categories",
+        "metadata.teaser",
+        "created_at",
+      ])
+      .sort("-created_at");
+    return data?.objects || [];
+  } catch (error) {
+    logError("getPublishedPostsForHomeTwin", error, {
+      bucketSlug: BUCKET_SLUG || "",
+      hasReadKey: !!READ_KEY,
+    });
+    return [];
+  }
+}
+
+/** Published-only category listing for markdown twins (ignores local draft ENV). */
+export async function getPublishedPostsForCategoryTwin(categorySlug: string) {
+  if (!hasCosmicCredentials()) {
+    return {
+      categoryPosts: [],
+      categoryName: undefined,
+    };
+  }
+  try {
+    const categoryDetails = await getCategoryDetails(categorySlug);
+
+    if (!categoryDetails) {
+      return {
+        categoryPosts: [],
+        categoryName: undefined,
+      };
+    }
+
+    const data = await cosmic.objects
+      .find({
+        type: "posts",
+        status: "published",
+        "metadata.categories": {
+          $in: [categoryDetails.id],
+        },
+      })
+      .props([
+        "id",
+        "title",
+        "slug",
+        "metadata.hero",
+        "metadata.content",
+        "metadata.teaser",
+        "metadata.categories",
+        "created_at",
+      ]);
+
+    return {
+      categoryPosts: data?.objects.length ? data?.objects : [],
+      categoryName: categoryDetails.title || undefined,
+    };
+  } catch (error) {
+    if (is404(error)) {
+      return {
+        categoryPosts: [],
+        categoryName: undefined,
+      };
+    }
+    logError("getPublishedPostsForCategoryTwin", error, {
+      categorySlug,
+      bucketSlug: BUCKET_SLUG || "",
+      hasReadKey: !!READ_KEY,
+    });
+    return {
+      categoryPosts: [],
+      categoryName: undefined,
+    };
+  }
+}
+
 export async function getPostAndMorePosts(slug: any) {
   try {
     const object = await cosmic.objects
@@ -205,6 +325,13 @@ export async function getPostAndMorePosts(slug: any) {
 }
 
 export async function getAllPostsForCategory(categorySlug: any) {
+  if (!hasCosmicCredentials()) {
+    return {
+      categoryPosts: [],
+      categoryName: undefined,
+    };
+  }
+
   try {
     const categoryDetails = await getCategoryDetails(categorySlug);
 

--- a/lib/llms/buildLlmsFull.ts
+++ b/lib/llms/buildLlmsFull.ts
@@ -1,7 +1,5 @@
-import fs from "fs";
-import path from "path";
-
 import { canonicalHostnameUrl } from "@constants/constants";
+import { readSection } from "@lib/markdown/readSection";
 import markdownToHtml from "@lib/markdownToHtml";
 import { stripHtmlToPlainText } from "@lib/plainText";
 
@@ -11,15 +9,6 @@ export type LlmsFullPost = {
   created_at?: string;
   metadata?: { teaser?: string };
 };
-
-function readSection(filename: string): string {
-  const filePath = path.join(process.cwd(), "content/llms", filename);
-  try {
-    return fs.readFileSync(filePath, "utf-8").trim();
-  } catch {
-    return `_Section content unavailable (${filename})._`;
-  }
-}
 
 function formatSection(title: string, url: string, body: string): string {
   return `# ${title}\n\nCanonical URL: ${url}\n\n${body}`;

--- a/lib/markdown/formatTwin.ts
+++ b/lib/markdown/formatTwin.ts
@@ -1,0 +1,7 @@
+export function formatTwin(
+  title: string,
+  canonicalUrl: string,
+  body: string
+): string {
+  return `# ${title}\n\nCanonical URL: ${canonicalUrl}\n\n${body}`;
+}

--- a/lib/markdown/pathSafety.ts
+++ b/lib/markdown/pathSafety.ts
@@ -1,0 +1,28 @@
+const UNSAFE_SEGMENT = /^(?:\.|%2e)$/i;
+
+export function isSafePathSegment(segment: string): boolean {
+  if (!segment || segment === ".." || UNSAFE_SEGMENT.test(segment)) {
+    return false;
+  }
+  if (segment.includes("\\") || segment.includes("\0")) {
+    return false;
+  }
+  try {
+    const decoded = decodeURIComponent(segment);
+    if (
+      decoded === ".." ||
+      decoded.includes("/") ||
+      decoded.includes("\\") ||
+      decoded.includes("\0")
+    ) {
+      return false;
+    }
+  } catch {
+    return false;
+  }
+  return true;
+}
+
+export function assertSafePathSegments(segments: string[]): boolean {
+  return segments.length > 0 && segments.every(isSafePathSegment);
+}

--- a/lib/markdown/readSection.ts
+++ b/lib/markdown/readSection.ts
@@ -1,0 +1,11 @@
+import fs from "fs";
+import path from "path";
+
+export function readSection(filename: string): string {
+  const filePath = path.join(process.cwd(), "content/llms", filename);
+  try {
+    return fs.readFileSync(filePath, "utf-8").trim();
+  } catch {
+    return `_Section content unavailable (${filename})._`;
+  }
+}

--- a/lib/markdown/resolveTwin.ts
+++ b/lib/markdown/resolveTwin.ts
@@ -1,0 +1,65 @@
+import { assertSafePathSegments } from "@lib/markdown/pathSafety";
+import { buildBlogCategoryTwin } from "@lib/markdown/twins/blogCategory";
+import { buildBlogPostTwin } from "@lib/markdown/twins/blogPost";
+import { buildCaseStudyTwin } from "@lib/markdown/twins/caseStudy";
+import {
+  buildBlogCategoryIndexTwin,
+  buildBlogIndexTwin,
+  buildContactTwin,
+  buildHomeTwin,
+  buildPortfolioTwin,
+} from "@lib/markdown/twins/marketing";
+
+export async function resolveTwinMarkdown(
+  pathSegments: string[]
+): Promise<string | null> {
+  if (!assertSafePathSegments(pathSegments)) {
+    return null;
+  }
+
+  const [first, second, third] = pathSegments;
+
+  if (pathSegments.length === 1 && first === "index") {
+    return buildHomeTwin();
+  }
+
+  if (pathSegments.length === 1 && first === "portfolio") {
+    return buildPortfolioTwin();
+  }
+
+  if (pathSegments.length === 1 && first === "contact") {
+    return buildContactTwin();
+  }
+
+  if (pathSegments.length === 1 && first === "blog") {
+    return buildBlogIndexTwin();
+  }
+
+  if (pathSegments.length === 2 && first === "blog" && second === "category") {
+    return buildBlogCategoryIndexTwin();
+  }
+
+  if (
+    pathSegments.length === 3 &&
+    first === "blog" &&
+    second === "category" &&
+    third
+  ) {
+    return buildBlogCategoryTwin(third);
+  }
+
+  if (
+    pathSegments.length === 3 &&
+    first === "blog" &&
+    second === "posts" &&
+    third
+  ) {
+    return buildBlogPostTwin(third);
+  }
+
+  if (pathSegments.length === 2 && first === "case-studies" && second) {
+    return buildCaseStudyTwin(second);
+  }
+
+  return null;
+}

--- a/lib/markdown/twinHeaders.ts
+++ b/lib/markdown/twinHeaders.ts
@@ -1,0 +1,10 @@
+export const twinMarkdownHeaders: Record<string, string> = {
+  "Content-Type": "text/markdown; charset=utf-8",
+  "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+  "CDN-Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+  "Netlify-CDN-Cache-Control":
+    "public, s-maxage=3600, stale-while-revalidate=86400",
+  "Cache-Tag": "markdown-twin, content",
+  "Netlify-Cache-Tag": "markdown-twin, content",
+  Vary: "Accept-Encoding",
+};

--- a/lib/markdown/twinUrl.ts
+++ b/lib/markdown/twinUrl.ts
@@ -1,0 +1,8 @@
+/** HTML path → markdown twin URL (KTD2). */
+export function twinUrl(htmlPath: string): string {
+  if (htmlPath === "/" || htmlPath === "") {
+    return "/index.md";
+  }
+  const normalized = htmlPath.endsWith("/") ? htmlPath.slice(0, -1) : htmlPath;
+  return `${normalized}.md`;
+}

--- a/lib/markdown/twins/blogCategory.ts
+++ b/lib/markdown/twins/blogCategory.ts
@@ -1,0 +1,58 @@
+import { canonicalHostnameUrl } from "@constants/constants";
+import { getPublishedPostsForCategoryTwin } from "@lib/api";
+import { formatTwin } from "@lib/markdown/formatTwin";
+import markdownToHtml from "@lib/markdownToHtml";
+import { stripHtmlToPlainText } from "@lib/plainText";
+
+async function teaserFromPost(post: {
+  metadata?: { teaser?: string };
+}): Promise<string> {
+  const rawTeaser = post.metadata?.teaser || "";
+  if (!rawTeaser.trim()) {
+    return "";
+  }
+  const teaserHtml = rawTeaser.startsWith("<")
+    ? rawTeaser
+    : await markdownToHtml(rawTeaser);
+  return stripHtmlToPlainText(teaserHtml).trim();
+}
+
+export async function buildBlogCategoryTwin(
+  categorySlug: string
+): Promise<string | null> {
+  const { categoryPosts, categoryName } =
+    (await getPublishedPostsForCategoryTwin(categorySlug)) || {};
+
+  if (!categoryName) {
+    return null;
+  }
+
+  const canonicalUrl = `${canonicalHostnameUrl}/blog/category/${categorySlug}`;
+  const lines = await Promise.all(
+    (categoryPosts || []).map(
+      async (post: {
+        title?: string;
+        slug?: string;
+        created_at?: string;
+        metadata?: { teaser?: string };
+      }) => {
+        const url = `${canonicalHostnameUrl}/blog/posts/${post.slug}`;
+        const teaser = await teaserFromPost(post);
+        let date = "";
+        if (post.created_at) {
+          const parsed = new Date(post.created_at);
+          if (!Number.isNaN(parsed.getTime())) {
+            date = parsed.toISOString().split("T")[0];
+          }
+        }
+        const heading = `### [${post.title}](${url})${date ? ` — ${date}` : ""}`;
+        return teaser ? `${heading}\n\n${teaser}` : heading;
+      }
+    )
+  );
+
+  const body =
+    lines.length > 0 ? lines.join("\n\n") : "_No posts in this category._";
+
+  return formatTwin(categoryName, canonicalUrl, body);
+}

--- a/lib/markdown/twins/blogPost.ts
+++ b/lib/markdown/twins/blogPost.ts
@@ -1,0 +1,43 @@
+import { canonicalHostnameUrl } from "@constants/constants";
+import { getPublishedPostForTwin } from "@lib/api";
+import { formatTwin } from "@lib/markdown/formatTwin";
+import markdownToHtml from "@lib/markdownToHtml";
+import { stripHtmlToPlainText } from "@lib/plainText";
+
+async function bodyFromContent(content: string): Promise<string> {
+  if (!content.trim()) {
+    return "";
+  }
+  if (!content.trimStart().startsWith("<")) {
+    return content.trim();
+  }
+  const html = await markdownToHtml(content);
+  return stripHtmlToPlainText(html).trim();
+}
+
+export async function buildBlogPostTwin(slug: string): Promise<string | null> {
+  const post = await getPublishedPostForTwin(slug);
+  if (!post) {
+    return null;
+  }
+  const title = post.title || slug;
+  const canonicalUrl = `${canonicalHostnameUrl}/blog/posts/${slug}`;
+  const content = post.metadata?.content || "";
+  const body = await bodyFromContent(content);
+  const categories = post.metadata?.categories || [];
+  const categoryLine =
+    categories.length > 0
+      ? `Categories: ${categories
+          .map((c: { title?: string }) => c.title)
+          .filter(Boolean)
+          .join(", ")}\n\n`
+      : "";
+  let dateLine = "";
+  if (post.created_at) {
+    const parsed = new Date(post.created_at);
+    if (!Number.isNaN(parsed.getTime())) {
+      dateLine = `Published: ${parsed.toISOString().split("T")[0]}\n\n`;
+    }
+  }
+  return formatTwin(title, canonicalUrl, `${dateLine}${categoryLine}${body}`);
+}

--- a/lib/markdown/twins/caseStudy.ts
+++ b/lib/markdown/twins/caseStudy.ts
@@ -1,0 +1,44 @@
+import fs from "fs";
+import path from "path";
+
+import { canonicalHostnameUrl } from "@constants/constants";
+import { formatTwin } from "@lib/markdown/formatTwin";
+
+export const CASE_STUDY_SLUGS = new Set([
+  "expedia",
+  "wheeltheworld",
+  "soleit",
+  "dockershelf",
+  "canaima",
+]);
+
+export function isCaseStudySlug(slug: string): boolean {
+  return CASE_STUDY_SLUGS.has(slug);
+}
+
+export async function buildCaseStudyTwin(slug: string): Promise<string | null> {
+  if (!isCaseStudySlug(slug)) {
+    return null;
+  }
+
+  const filePath = path.join(
+    process.cwd(),
+    "content/case-studies",
+    `${slug}.md`
+  );
+
+  let body: string;
+  try {
+    body = fs.readFileSync(filePath, "utf-8").trim();
+  } catch {
+    return null;
+  }
+
+  const titleMatch = body.match(/^#\s+(.+)/m);
+  const title = titleMatch?.[1] || slug;
+  const canonicalUrl = `${canonicalHostnameUrl}/case-studies/${slug}`;
+
+  const contentBody = body.replace(/^#\s+.+\n*/m, "").trim();
+
+  return formatTwin(title, canonicalUrl, contentBody);
+}

--- a/lib/markdown/twins/marketing.ts
+++ b/lib/markdown/twins/marketing.ts
@@ -1,0 +1,78 @@
+import { canonicalHostnameUrl } from "@constants/constants";
+import { getAllCategories, getPublishedPostsForHomeTwin } from "@lib/api";
+import { formatTwin } from "@lib/markdown/formatTwin";
+import { readSection } from "@lib/markdown/readSection";
+import markdownToHtml from "@lib/markdownToHtml";
+import { stripHtmlToPlainText } from "@lib/plainText";
+
+import type { LlmsFullPost } from "@lib/llms/buildLlmsFull";
+
+async function formatBlogListing(posts: LlmsFullPost[]): Promise<string> {
+  const lines = await Promise.all(
+    posts.map(async (post) => {
+      const url = `${canonicalHostnameUrl}/blog/posts/${post.slug}`;
+      const rawTeaser = post.metadata?.teaser || "";
+      const teaserHtml = rawTeaser.startsWith("<")
+        ? rawTeaser
+        : await markdownToHtml(rawTeaser);
+      const teaser = stripHtmlToPlainText(teaserHtml).trim();
+      let date = "";
+      if (post.created_at) {
+        const parsed = new Date(post.created_at);
+        if (!Number.isNaN(parsed.getTime())) {
+          date = parsed.toISOString().split("T")[0];
+        }
+      }
+      const heading = `### [${post.title}](${url})${date ? ` — ${date}` : ""}`;
+      return teaser ? `${heading}\n\n${teaser}` : heading;
+    })
+  );
+  return lines.join("\n\n") || "_No posts available._";
+}
+
+export async function buildHomeTwin(): Promise<string> {
+  return formatTwin("Home", `${canonicalHostnameUrl}/`, readSection("home.md"));
+}
+
+export async function buildPortfolioTwin(): Promise<string> {
+  return formatTwin(
+    "Portfolio",
+    `${canonicalHostnameUrl}/portfolio`,
+    readSection("portfolio.md")
+  );
+}
+
+export async function buildContactTwin(): Promise<string> {
+  return formatTwin(
+    "Contact",
+    `${canonicalHostnameUrl}/contact`,
+    readSection("contact.md")
+  );
+}
+
+export async function buildBlogIndexTwin(): Promise<string> {
+  const posts = (await getPublishedPostsForHomeTwin()) || [];
+  const body = await formatBlogListing(posts);
+  return formatTwin("Blog Index", `${canonicalHostnameUrl}/blog`, body);
+}
+
+export async function buildBlogCategoryIndexTwin(): Promise<string> {
+  const categories = (await getAllCategories()) || [];
+  const lines = categories.map(
+    (category: { title?: string; slug?: string }) => {
+      const title = category.title || category.slug || "Category";
+      const slug = category.slug || "";
+      const url = `${canonicalHostnameUrl}/blog/category/${slug}`;
+      return `- [${title}](${url})`;
+    }
+  );
+  const body =
+    lines.length > 0
+      ? `## Categories\n\n${lines.join("\n")}`
+      : "_No categories available._";
+  return formatTwin(
+    "Blog Categories",
+    `${canonicalHostnameUrl}/blog/category`,
+    body
+  );
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -182,11 +182,22 @@ const config: NextConfig = {
         headers: [
           {
             key: "Link",
-            value: '</llms.txt>; rel="describedby"; type="text/markdown"',
+            value:
+              '</llms.txt>; rel="describedby"; type="text/markdown", </.well-known/api-catalog>; rel="api-catalog"',
           },
         ],
       },
     ];
+  },
+  async rewrites() {
+    return {
+      afterFiles: [
+        {
+          source: "/:path((?!(?:_next|api|\\.well-known)).*)\\.md",
+          destination: "/markdown-twin/:path",
+        },
+      ],
+    };
   },
   experimental: {
     optimizePackageImports: ["yet-another-react-lightbox"],

--- a/public/agents.md
+++ b/public/agents.md
@@ -17,6 +17,7 @@ Use these sources before broad crawling:
 - `https://luisalejandro.org/blog/posts/feed.json` for the JSON feed.
 - `https://luisalejandro.org/ai.txt` for attribution preferences.
 - `https://luisalejandro.org/.well-known/agent-permissions.json` for browser-agent interaction permissions.
+- `https://luisalejandro.org/.well-known/api-catalog` for RFC 9727 API discovery (also advertised via HTTP `Link: rel="api-catalog"`).
 
 ## How To Interpret Pages
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -43,6 +43,7 @@ This file is the preferred starting point for AI assistants, answer engines, and
 - AI attribution policy: https://luisalejandro.org/ai.txt
 - Agent instructions: https://luisalejandro.org/agents.md
 - Agent permissions: https://luisalejandro.org/.well-known/agent-permissions.json
+- API catalog (RFC 9727): https://luisalejandro.org/.well-known/api-catalog
 
 ## Content Use Guidance
 


### PR DESCRIPTION
## Summary

Agents and AI crawlers can now retrieve machine-readable markdown equivalents of site pages without scraping HTML. Each supported route exposes a `.md` twin (for example `/portfolio.md`), linked from HTML via `rel="alternate" type="text/markdown"`, global `Link: describedby` headers, and an RFC 9727 `application/linkset+json` catalog at `/.well-known/api-catalog`. `robots.txt` declares `Content-Signal` policy (search, ai-input, ai-train) on the wildcard group and every named AI crawler block.

`llms-full.txt` remains the aggregate corpus; per-route twins complement it for page-scoped fetches. Blog post twins are published-only so draft previews do not advertise twins that 404.

Case study twins ship as executive summaries in this phase; full text-equivalent parity is tracked separately in the SEO roadmap (Phase 6).

## Test plan

- [x] `yarn type-check`
- [ ] `yarn build`
- [ ] `GET /robots.txt` — `Content-Signal` on `*` and each AI crawler stanza
- [ ] `GET /.well-known/api-catalog` — valid linkset JSON
- [ ] `GET /portfolio.md`, `/blog.md`, `/case-studies/expedia.md` — `text/markdown` body with canonical URL header
- [ ] Draft blog post locally — no `text/markdown` alternate in metadata
