### PR TITLE
feat(seo): cache TTLs, CDN purge, and case study twins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ RECAPTCHA_API_SECRET=
 DISQUS_API_KEY=
 REVALIDATE_SECRET=
 
+# Netlify on-demand cache purge (Cosmic publish webhook)
+NETLIFY_PURGE_TOKEN=
+NETLIFY_SITE_ID=
+
 # Error monitoring (Sentry)
 NEXT_PUBLIC_SENTRY_DSN=
 SENTRY_DSN=

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -2,6 +2,10 @@ import { revalidatePath } from "next/cache";
 import { NextRequest, NextResponse } from "next/server";
 
 import { logError } from "@lib/logger";
+import { BLOG_PURGE_TAGS, purgeByTags } from "@lib/netlify/purgeByTags";
+
+const MAX_REVALIDATE_ITEMS = 50;
+const SLUG_PATTERN = /^[a-z0-9-]+$/;
 
 interface RevalidateRequestBody {
   posts?: Array<{
@@ -12,9 +16,12 @@ interface RevalidateRequestBody {
   }>;
 }
 
+function isValidSlug(slug: string): boolean {
+  return SLUG_PATTERN.test(slug);
+}
+
 export async function POST(request: NextRequest) {
   try {
-    // Check for secret to prevent unauthorized revalidation
     const secret = request.nextUrl.searchParams.get("secret");
 
     if (!secret || secret !== process.env.REVALIDATE_SECRET) {
@@ -25,37 +32,46 @@ export async function POST(request: NextRequest) {
 
     const revalidatedPaths: string[] = [];
 
-    // Always revalidate the main blog page
     revalidatePath("/blog");
     revalidatedPaths.push("/blog");
 
-    // Revalidate specific post pages
+    revalidatePath("/markdown-twin/blog");
+    revalidatedPaths.push("/markdown-twin/blog");
+
     if (body.posts && Array.isArray(body.posts)) {
-      for (const post of body.posts) {
-        if (post.slug) {
+      for (const post of body.posts.slice(0, MAX_REVALIDATE_ITEMS)) {
+        if (post.slug && isValidSlug(post.slug)) {
           const postPath = `/blog/posts/${post.slug}`;
           revalidatePath(postPath);
           revalidatedPaths.push(postPath);
+
+          const twinPath = `/markdown-twin/blog/posts/${post.slug}`;
+          revalidatePath(twinPath);
+          revalidatedPaths.push(twinPath);
         }
       }
     }
 
-    // Revalidate specific category pages
     if (body.categories && Array.isArray(body.categories)) {
-      for (const category of body.categories) {
-        if (category.slug) {
+      for (const category of body.categories.slice(0, MAX_REVALIDATE_ITEMS)) {
+        if (category.slug && isValidSlug(category.slug)) {
           const categoryPath = `/blog/category/${category.slug}`;
           revalidatePath(categoryPath);
           revalidatedPaths.push(categoryPath);
+
+          const twinPath = `/markdown-twin/blog/category/${category.slug}`;
+          revalidatePath(twinPath);
+          revalidatedPaths.push(twinPath);
         }
       }
     }
 
-    // Also revalidate the main category index page
     revalidatePath("/blog/category");
     revalidatedPaths.push("/blog/category");
 
-    // Revalidate feeds and sitemap since blog content changed
+    revalidatePath("/markdown-twin/blog/category");
+    revalidatedPaths.push("/markdown-twin/blog/category");
+
     revalidatePath("/blog/posts/feed.xml");
     revalidatePath("/blog/posts/atom.xml");
     revalidatePath("/blog/posts/feed.json");
@@ -67,12 +83,35 @@ export async function POST(request: NextRequest) {
       "/sitemap.xml"
     );
 
+    revalidatePath("/llms-full.txt");
+    revalidatedPaths.push("/llms-full.txt");
+
+    const purgedTags = [...BLOG_PURGE_TAGS];
+    const purgeResult = await purgeByTags(purgedTags);
+
+    if (!purgeResult.ok && purgeResult.reason !== "missing_env") {
+      logError(
+        "revalidate-api-purge",
+        new Error(`Netlify purge failed: ${purgeResult.reason ?? "unknown"}`),
+        {
+          purgedTags,
+          status: purgeResult.status,
+        }
+      );
+    }
+
     console.log(`[revalidate-api] Revalidation completed successfully`, {
       revalidatedPaths,
+      purgeOk: purgeResult.ok,
+      purgeError: purgeResult.ok ? undefined : purgeResult.reason,
     });
+
     return NextResponse.json({
       message: "Revalidation completed successfully",
       revalidatedPaths,
+      purgedTags,
+      purgeOk: purgeResult.ok,
+      purgeError: purgeResult.ok ? undefined : purgeResult.reason,
       timestamp: new Date().toISOString(),
     });
   } catch (error) {

--- a/content/case-studies/README.md
+++ b/content/case-studies/README.md
@@ -1,5 +1,24 @@
 # Case study markdown twins
 
-Hand-authored markdown mirrors the narrative on each case study page. Update these files when case study copy changes on the React pages.
+Hand-authored markdown mirrors the narrative on each case study page. Twins are served at `/case-studies/{slug}.md` and linked from HTML via `rel="alternate" type="text/markdown"`.
 
-Twins are served at `/case-studies/{slug}.md` and linked from HTML via `rel="alternate" type="text/markdown"`.
+## Text-equivalent maintenance
+
+Each twin must be **text-equivalent** to its React page: the same copy, structure, stats, and outbound links as a reader would get from the HTML narrative (minus chrome only).
+
+**Source of truth:** `app/case-studies/{slug}/page.tsx` — extract from `HeroIntro`, `Why`, `Challenge`, `Product`, and `Results`.
+
+**Required sections in every twin:**
+
+1. `# Title` — from `HeroIntro` `Title`
+2. Subtitle line, intro paragraphs, then metadata: **Year**, **Team**, **Deliverables**, **Links** (markdown links when present)
+3. `## The Problem` — from `Why`
+4. `## The Challenge` — from `Challenge`
+5. `## The Product` — from `Product`
+6. `## The Results` — from `Results` (stat boxes as prose or tables; gallery URLs as `_[Image: description — url]_`)
+
+**Do not include:** Header, Footer, Contact, ScrollMagic, Chart.js charts, SVG animation, or other non-narrative UI.
+
+**When to update:** Change the matching `content/case-studies/{slug}.md` in the **same PR** whenever case study copy changes in `page.tsx`. Stub-length files (~15 lines) are not acceptable once expanded.
+
+**Routing:** `lib/markdown/twins/caseStudy.ts` reads these files, strips the leading `# Title`, and wraps output via `lib/markdown/formatTwin.ts`.

--- a/content/case-studies/canaima.md
+++ b/content/case-studies/canaima.md
@@ -1,15 +1,82 @@
-# Canaima GNU/Linux
+# A Venezuelan Linux Distribution
 
-Linux distribution and public-sector free software work reaching hundreds of thousands of users.
+Canaima GNU/Linux
 
-## Challenge
+Canaima GNU/Linux is a free and open-source Linux distribution that is based on the Debian architecture.
 
-Deliver a Venezuelan GNU/Linux distribution suitable for education and public institutions with sustainable packaging and release practices.
+**Year:** 2009
 
-## Approach
+**Team:**
 
-Contributed to distribution engineering, community packaging, and tooling that supports national-scale deployment.
+- Luis Martínez
+- Carlos Parra
+- Erick Birbe
+- Sasha Solano
+- Francisco Vásquez
 
-## Results
+**Deliverables:**
 
-Canaima has reached 220K+ users, advancing free software adoption in public-sector and educational contexts.
+- Debian packages
+- ISO images
+- Documentation
+- Artwork
+
+**Links:**
+
+- [Homepage](https://canaima.softwarelibre.gob.ve/)
+- [Source code](https://gitlab.com/canaima-gnu-linux)
+
+## The Problem
+
+The venezuelan government was looking for a way to migrate their infrastructure to a free and open-source operating system. They needed a method that could allow them to deploy software in a secure, centralized and reliable way to their millions of users across the country.
+
+Debian as an operating system, provided the stability and security that the government was looking for. However, the process of being accepted as a maintainer in Debian was long and tedious. The government needed to introduce hundreds of packages, without having to wait for the Debian maintainers to accept their packages.
+
+## The Challenge
+
+Leading a team of developers to create a Linux distribution is a tough job, but in the case of Canaima was even harder because we had to reach consensus with the user community while at the same time we had to meet the requirements of the government. We had annual events called "Cayapas" were we tried to get the community involved in the development of the distribution.
+
+We had to develop our own infraestructure to support the growing of the features we were adding to the distribution. We had to develop our own build system, our own package repository, and our own website.
+
+## The Product
+
+Canaima GNU/Linux had several components that needed to be functioning properly so that the distribution could be used. It had a website, a wiki, a forum, a mailing list, a bug tracker, a source code repository, a build system, a package repository, a download server, and a documentation server. All of these components needed to be working together in order to provide a good experience to the users.
+
+The build system was based on Debian's build system. We called it "Canaima Semilla". It was a set of scripts that would build the packages and the ISO images. The build system was able to build the packages for different architectures, and it was able to build the ISO images for different flavors of the distribution.
+
+We also made our own web browser, called "Cunaguaro". It was based on Firefox, but it had a different logo and it had some customizations that were specific to the distribution.
+
+_[Image: Product demo video — /images/case-studies/canaima-product.mp4]_
+
+## The Results
+
+Canaima enjoyed a lot of popularity in Venezuela. It was used in schools, universities, government offices, and even in the military. On the first month of release of Canaima 3.0, it had 110,000 downloads and subsequent releases were also popular.
+
+| Release | Downloads |
+| --- | --- |
+| Canaima 3.0 | 110K |
+| Canaima 3.1 | 150K |
+| Canaima 4.0 | 220K |
+
+As a Canaima developer, I was able to assist to the 12th annual debian developers conference, which was held in Managua, Nicaragua. I was able to meet other Debian developers, including the creator of Live Build, which was the base for Canaima Semilla.
+
+_[Image: Conference photo 1 — /images/case-studies/canaima-gallery-1.png]_
+
+_[Image: Conference photo 2 — /images/case-studies/canaima-gallery-2.png]_
+
+_[Image: Conference photo 3 — /images/case-studies/canaima-gallery-3.png]_
+
+_[Image: Conference photo 4 — /images/case-studies/canaima-gallery-4.png]_
+
+_[Image: Conference photo 5 — /images/case-studies/canaima-gallery-5.jpg]_
+
+_[Image: Conference photo 6 — /images/case-studies/canaima-gallery-6.jpg]_
+
+_[Image: Conference photo 7 — /images/case-studies/canaima-gallery-7.jpg]_
+
+_[Image: Conference photo 8 — /images/case-studies/canaima-gallery-8.jpg]_
+
+**Links:**
+
+- [Homepage](https://canaima.softwarelibre.gob.ve/)
+- [Source code](https://gitlab.com/canaima-gnu-linux)

--- a/content/case-studies/dockershelf.md
+++ b/content/case-studies/dockershelf.md
@@ -1,15 +1,80 @@
-# Dockershelf
+# Reliable docker images
 
-Dockershelf is a repository that serves as a collector for docker recipes that are universal, efficient and slim. Shelves hold different versions of popular languages or applications. Images are updated, tested and published weekly via a GitHub Actions workflow.
+Dockershelf
 
-## Challenge
+Dockershelf is a repository that serves as a collector for docker recipes that are universal, efficient and slim. We keep adding "shelves", which are holders for the different versions of a popular language or application. Images are updated, tested and published weekly via a Github Actions workflow.
 
-Developers need dependable, slim base images across Python, Node, Debian, and LaTeX stacks without maintaining one-off Dockerfiles in every project.
+**Year:** 2016
 
-## Approach
+**Team:**
 
-Dockershelf automates image builds, publishes versioned shelves, and optimizes image size compared with many official images.
+- Luis Martínez
 
-## Results
+**Deliverables:**
 
-The catalog has grown to 294K+ downloads with images often several times smaller than official equivalents, supporting CI/CD and local development workflows.
+- Debian images
+- Python images
+- Node images
+- Latex images
+
+**Links:**
+
+- [Github](https://github.com/Dockershelf/dockershelf)
+- [Dockerhub](https://hub.docker.com/u/dockershelf)
+
+## The Problem
+
+As **software engineer**, I was always looking for a way to **be more efficient** with my time. One of the challenges that I faced was the need to have a reliable and fast way to build and deploy my applications. I started using **docker**, but at the time all docker images were based on debian stable or ubuntu. The first had legacy software, and the latter was too unstable to be used in production. I needed at least a **debian testing or sid** image, but there were none available. So I decided to build my own.
+
+Soon, I started to unit test **python apps** and needed docker images for different versions. I also needed to build node apps, and latex documents. I started to build my own images for all of them, and I realized that I could share them with the community. That's how **Dockershelf** was born.
+
+## The Challenge
+
+I wanted the project to be **sustainable** and completely **open source**. This meant that I needed to use services that were free and publicly accessible. Also, I wanted it to be completely unmantained, or at least the mantainance to be as minimal as possible. This meant that I needed to **automate everything**, from the build process to the publishing of images.
+
+The automation presented a problem, because I could inadvertently publish a broken image. I needed a way to **test the images** before publishing them.
+
+I also wanted to use the debian packaging system to install the needed software, because for example official python and node images were built from source and that made them **prone to errors and inconsistencies**. This also meant that I needed to build the images from **scratch**, and not use any of the existing images as a base.
+
+## The Product
+
+I came up with a way to automate the build process using Travis CI. I created templates for the pipeline configuration, which would create the actual configuration containing the list of images to build. I could control the specific versions of python or node to build, depending on its popularity and availability of the software in the debian repositories. I experienced a setback when Travis CI became a paid service, so I had to migrate to Github Actions.
+
+I decided to focus on the images I was going to need for my projects: Debian, Python and Node. I also added a Latex one to write my CV. I needed them to be based on debian sid for development purposes but I later added a Debian stable version for production. Initially they were all amd64 images but I later added arm64 for mac users.
+
+I created a test suite for the images, which would run on every build. The test suite would check that the images were built correctly and that the software was installed and working. The builds are run weekly, and the images are published to Dockerhub if the tests pass.
+
+_[Image: Product demo video — /images/case-studies/dockershelf-product.mov]_
+
+## The Results
+
+My intention with dockershelf was to be a personal project, but it turned out to be something more. Several people started using the images and I started to receive feedback and contributions. The project has also been featured in the awesome-docker repository, and it has been starred more than 60 times.
+
+| Metric | Value |
+| --- | --- |
+| Downloads on debian images | 220K |
+| Downloads on python images | 294K |
+| Downloads on node images | 55K |
+
+The difference in size between the official images and the dockershelf ones are significant. The Python and Node images are 4 times smaller, making them faster to download and use. Although not as small as Alpine, they are still a good alternative for those who need a Debian based image.
+
+**Node image size (MB)**
+
+| Image | Size (MB) |
+| --- | --- |
+| dockerhub node | 367.93 |
+| dockershelf node | 82.43 |
+
+**Python image size (MB)**
+
+| Image | Size (MB) |
+| --- | --- |
+| dockerhub python | 360.46 |
+| dockershelf python | 100.09 |
+
+The project is still active and I keep adding new images and arquitectures when possible. You can checkout the project on Github or contact me for more information.
+
+**Links:**
+
+- [Github](https://github.com/Dockershelf/dockershelf)
+- [Dockerhub](https://hub.docker.com/u/dockershelf)

--- a/content/case-studies/expedia.md
+++ b/content/case-studies/expedia.md
@@ -1,15 +1,51 @@
-# Expedia API Integration
+# A larger hotel database to book from
 
-Case study for Wheel The World: integrating Expedia's booking APIs into a travel platform that serves travelers with accessibility needs.
+Expedia API integration
 
-## Challenge
+On 2022, Wheel the World pursued a commercial agreement with Expedia to integrate their hotel database booking and shopping features. I was in charge of developing several components to make this integration possible.
 
-Connect hotel inventory and booking flows to Expedia's partner APIs while keeping latency and error handling production-grade for a high-traffic consumer product.
+**Year:** 2022
 
-## Approach
+**Team:**
 
-Designed API integration layers, caching, and booking orchestration aligned with Wheel The World's product requirements.
+- Luis Martínez
 
-## Results
+**Deliverables:**
 
-Contributed to measurable booking conversion improvements (39% booking boost cited in portfolio materials) through reliable Expedia-powered search and checkout paths.
+- An expedia content indexer
+- A booking module
+- A shopping module
+- A matching algorithm
+
+## The Problem
+
+Wheel the World needed to increase their sales significantly if they wanted to keep growing. They had a great product, but they needed to reach more people. One of the main problems was that they had a very limited hotel database, which made it difficult for users to find a hotel that suited their needs. They had an integration with Hotelbeds, but the available inventory was very limited.
+
+The majority of hotels in the wheel The World inventory were bookable through a request to quote system, but this meant that users had to wait for a response from the Wheel the World team, which was not scalable. Also, pricing was not transparent or instant, which made it difficult for users to make a decision.
+
+## The Challenge
+
+There was already a request to quote system and a booking/pricing integration with Hotelbeds in place. One of the challenges was to integrate the Expedia hotel database with a new booking/pricing system, and to make it work with the existing request to quote system. Rewriting or moving components of the system design was not an option, so the new system had to be compatible with the existing one.
+
+One of the components needed to index all of the Expedia content database and make it searchable. This component had to be able to index the content in a reasonable amount of time, and it had to be able to update the index on a weekly basis. What made this challenging was that there were more tha 600k records in the database, with a total of 28GB of data.
+
+The matching system was also a headeache. It had to be able to match the Expedia content with the Wheel the World content, but also allowing to match with Hotelbeds content.
+
+## The Product
+
+The integration consisted first on a Golang application that downloaded, parsed and saved the Expedia content database (28GB of data) into a Postgres database and a Redis cache. This application was able to download and parse the whole database in less than 2 hours, and it was able to update the database on a weekly basis in less than 2 minutes.
+
+The second part of the integration was a to add a Pricing and a Shopping provider for Expedia in the website backend. The backend was built with Express and TypeORM (Typescript), and it was deployed on Google Clour Run. The pricing provider was able to get the availability and price of a hotel room for a given date, and the booking provider was able to book a hotel room.
+
+The third part of the integration was to add a matching algorithm that was able to match the Expedia content with the Wheel the World content, but also allowing to match with Hotelbeds content. This was a very complex algorithm that had to take into account the location, the accessibility features, the hotel amenities, the room amenities, the room type, the room accessibility features and other factors. It used the indexed data from the first part of the integration to make the matching process faster.
+
+_[Image: Product demo video — /images/case-studies/expedia-product.mov]_
+
+## The Results
+
+The integration was a success. Expedia quickly certified the integration and allowed Wheel the World to increase their hotel database from a couple of thousand hotels to more than 600k hotels. This allowed Wheel the World to increase their sales by 39% on the first quarter of 2023.
+
+| Metric | Value |
+| --- | --- |
+| Hotels to choose from | 600K |
+| Increase in bookings | 39% |

--- a/content/case-studies/soleit.md
+++ b/content/case-studies/soleit.md
@@ -1,15 +1,81 @@
-# Soleit Desktop App
+# A desktop app for kinesiology
 
-Electron and Ionic React diagnostic desktop application for field technicians.
+Soleit
 
-## Challenge
+The first automated biomechanical design software. An easier, more accurate, faster process to generate motion analysis and personalized insole 3D model.
 
-Technicians needed an offline-capable desktop tool to run hardware diagnostics with a consistent UX across operating systems.
+**Year:** 2021
 
-## Approach
+**Team:**
 
-Delivered a cross-platform Electron shell with Ionic React UI components and structured diagnostic workflows.
+- Luis Martínez
+- Saraí Santiago
+- Israel Lugo
+- Sergi Prats
 
-## Results
+**Deliverables:**
 
-A maintainable desktop product that supports technicians in the field with a modern, branded interface.
+- A REST api
+- A desktop app
+- A hardware driver
+
+**Links:**
+
+- [Client site](https://soleit.app/en/how-it-works/)
+
+## The Problem
+
+This client had plans for growing its current portfolio in Chile and expanding to the United States with a Series B round of investors. To achieve those important goals, they needed to get rid of many of their manual processes and automate them. Also, many of these algorithms were scattered in different places and needed to be unified in a single app.
+
+As the diagnosis of feet is a very important part of the product, the client needed a way to connect the hardware to the app. The hardware was a 3D scanner that was connected to a computer via USB. The app needed to be able to communicate with the hardware and receive the data from the scanner.
+
+The client had a very clear idea of what they wanted to achieve, but they needed help to make it happen. They needed a team that could help them with the architecture, the development, and the deployment of the app.
+
+## The Challenge
+
+The application needed to be a desktop app as part of the bussiness model was to sell the access as a subscription. The client wanted to avoid the possibility of the users to share their credentials with other people. To achieve this, the app needed to be a desktop app that could be installed in the user's computer. This way, the app could be used only by the person that bought the subscription.
+
+The app needed to be able to communicate with the hardware. We only had a low level driver from the manufactirer that allowed us to make very basic operations on the scanner, so a lot of work was needed to make the scanner work as expected. The fact that it was a closed source driver made the process even harder.
+
+## The Product
+
+The app was developed using **Electron**, a framework that allows to create desktop apps using web technologies. As a frontend language we selected **Ionic React**, so that the client could build the application for mobile devices in the future. The backend was developed using **Node.js** and **Express.js**. The database was a **PostgreSQL database** hosted in **AWS**. It also had connections with the propietary software that made the diagnosis of the feet, which was accessed through **DynamoDB**, and it was also integrated with the S3 bucket where the auxiliary files were stored.
+
+The hardware driver was embedded in the electron window and was written in python. It exposed a couple of endpoints that allowed the app to communicate with the hardware.
+
+The app allows Soleit to make new foot diagnoses, but also, manage users, doctors, materials, directions and more.
+
+_[Image: Product demo video — /images/case-studies/soleit-product.mov]_
+
+## The Results
+
+Soleit is now able to make diagnoses in a **more efficient way**, allowing them to grow their business and expand to new markets. They have made a **lot of sales** and are now looking to improve some of the features of the app.
+
+| Metric | Value |
+| --- | --- |
+| Diagnosed patients | more than 1000 |
+| Sold subscriptions | more than 20 |
+
+Here are some of the screenshots of the app:
+
+_[Image: App screenshot 1 — /images/case-studies/soleit-gallery-1.png]_
+
+_[Image: App screenshot 2 — /images/case-studies/soleit-gallery-2.png]_
+
+_[Image: App screenshot 3 — /images/case-studies/soleit-gallery-3.png]_
+
+_[Image: App screenshot 4 — /images/case-studies/soleit-gallery-4.png]_
+
+_[Image: App screenshot 5 — /images/case-studies/soleit-gallery-5.png]_
+
+_[Image: App screenshot 6 — /images/case-studies/soleit-gallery-6.png]_
+
+_[Image: App screenshot 7 — /images/case-studies/soleit-gallery-7.png]_
+
+_[Image: App screenshot 8 — /images/case-studies/soleit-gallery-8.png]_
+
+_[Image: App screenshot 9 — /images/case-studies/soleit-gallery-9.png]_
+
+**Links:**
+
+- [Client site](https://soleit.app/en/how-it-works/)

--- a/content/case-studies/wheeltheworld.md
+++ b/content/case-studies/wheeltheworld.md
@@ -1,15 +1,63 @@
-# Wheel The World CI/CD
+# A faster, stronger pipeline
 
-CI/CD reliability and cost optimization work for Wheel The World's engineering organization.
+Wheel The World
 
-## Challenge
+Wheel The World had a problem: their CI/CD pipeline was slow, unreproducible and unreliable. I helped them build a new one from scratch, using Github Actions and Docker.
 
-Pipeline instability and cloud spend were slowing releases for a distributed product team serving travelers worldwide.
+**Year:** 2022
 
-## Approach
+**Team:**
 
-Hardened deployment pipelines, improved observability, and tuned infrastructure usage without sacrificing release velocity.
+- Luis Martínez
+- Fede Carossino
+- Gonzalo Rodríguez
+- Sebastián Vinci
 
-## Results
+**Deliverables:**
 
-More dependable releases and reduced operational toil, enabling the team to ship product changes with greater confidence.
+- Github Actions CI/CD
+
+## The Problem
+
+On 2022, I joined Wheel The World as a software engineer as part of a reestructuring of the company. They needed to scale up the team to deliver new features continuosly and reliably. I quickly noticed that the current CI/CD schema was going to be a bottleneck for the team, so I proposed to redesign it by dropping what wasnt working and build on top of that. Luckily, the CTO was thinking the same thing, so we started working on it right away.
+
+## The Challenge
+
+Wheel the world used to have a CI/CD pipeline based on Google Cloud Build. This pipeline was slow, unreliable and hard to maintain. It was also hard to reproduce locally, which made it hard to debug. Furthermore, the results of the testing were not connected to the deploy trigger, which meant that a failed test would not stop the deploy automatically. This led to a lot of manual work and a lot of time wasted.
+
+To complicate things even more, wheel the world was not using Docker at all. This meant that the environment in which the code was tested was not the same as the one in which it was deployed. This led to a lot of bugs that were hard to reproduce and fix.
+
+The Google Cloud Build pipeline wasnt able to provide parallelization, caching or more complex workflows, limiting the capacity to improve the overall CI/CD process.
+
+## The Product
+
+The first thing I did was to dockerize all the services and the tests of the most important applications. This allowed the team to have a consistent environment for testing and development, regardless of the operating system or local library versions. Next was to deprecate the old pipeline based on Google Cloud Build and replace it with a new one based on Github Actions. This allowed us to have a more flexible and powerful pipeline, with parallelization, caching and more complex workflows.
+
+Implementing the branch and merge workflow proposed by the CTO, I was able to reduce the time to deploy significantly and do interesting things like automatically deploy the master branch to production when all the tests pass. On a second iteration, by reducing the size of the docker images using multistage builds and dividing the tests in different jobs, I was able to reduce the time to deploy even more.
+
+## The Results
+
+The new pipeline is faster, more reliable and easier to maintain. Taking only the website as an example, the total weight of the docker image went from 1.5GB to 200MB, the time to deploy went from 40 minutes to 10 minutes and the time to run the tests went from 20 minutes to 5 minutes.
+
+**Image size (MB)**
+
+| Pipeline | Image size (MB) |
+| --- | --- |
+| original pipeline | 1500 |
+| first iteration | 400 |
+| second iteration | 200 |
+
+**Time to deploy (minutes)**
+
+| Pipeline | Time to deploy (minutes) |
+| --- | --- |
+| original pipeline | 40 |
+| first iteration | 20 |
+| second iteration | 10 |
+
+By reducing the aount of time it takes to deploy and the weight of the images, we were reducing the maintenance cost of the pipeline, which was a big win for the company. For example, for the website frontend, estimating a cost of 0.008 USD per minute of deployment, and 5 pipeline runs per day (which is a conservative estimation), we were able to reduce the cost of the pipeline from 32 USD per month to 8 USD per month (75% reduction), just for one application.
+
+| Metric | Value |
+| --- | --- |
+| Reduction in costs for GitHub Actions | ~75% |
+| Reduction in image size | ~86% |

--- a/lib/netlify/purgeByTags.ts
+++ b/lib/netlify/purgeByTags.ts
@@ -1,0 +1,48 @@
+export const BLOG_PURGE_TAGS = [
+  "blog-posts",
+  "blog-index",
+  "blog-listings",
+] as const;
+
+export type PurgeByTagsResult = {
+  ok: boolean;
+  reason?: "missing_env" | "rate_limited" | "upstream_error";
+  status?: number;
+};
+
+export async function purgeByTags(
+  tags: readonly string[]
+): Promise<PurgeByTagsResult> {
+  const token = process.env.NETLIFY_PURGE_TOKEN;
+  const siteId = process.env.NETLIFY_SITE_ID;
+
+  if (!token || !siteId) {
+    return { ok: false, reason: "missing_env" };
+  }
+
+  try {
+    const response = await fetch("https://api.netlify.com/api/v1/purge", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        site_id: siteId,
+        cache_tags: [...tags],
+      }),
+    });
+
+    if (response.status === 429) {
+      return { ok: false, reason: "rate_limited", status: 429 };
+    }
+
+    if (!response.ok) {
+      return { ok: false, reason: "upstream_error", status: response.status };
+    }
+
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: "upstream_error" };
+  }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -22,14 +22,8 @@ const config: NextConfig = {
     return [
       // Forever cache for blog posts - content is immutable once published
       {
-        source: "/blog/posts/:slug*",
-        has: [
-          {
-            type: "header",
-            key: "x-matched-path",
-            value: "(?!.*(feed\\.xml|atom\\.xml|feed\\.json))",
-          },
-        ],
+        source:
+          "/blog/posts/:slug((?!feed\\.xml$)(?!atom\\.xml$)(?!feed\\.json$).+)",
         headers: [
           {
             key: "Cache-Control",

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,14 @@
+/llms.txt
+  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+
+/ai.txt
+  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+
+/.well-known/*
+  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+
+/images/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/favicon/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Summary

Blog publishes from Cosmic now invalidate Netlify CDN cache by tag after ISR, so pages with year-long immutable cache headers do not keep serving stale HTML when content changes. Discovery files and assets get explicit TTLs at the edge, and case study markdown twins carry the full page narrative agents expect when following `rel="alternate"` links.

## What changed

- **CDN purge on publish** — `/api/revalidate` calls Netlify purge API for `blog-posts`, `blog-index`, and `blog-listings` after existing `revalidatePath` work. Fail-open when env vars are missing or purge rate-limits; response includes `purgeOk` / `purgeError` for operators.
- **ISR coverage** — Revalidates markdown twin destinations (`/markdown-twin/blog`, category index, per-post/category twins) and `/llms-full.txt` on publish.
- **Cache headers** — `public/_headers` sets discovery/asset TTLs; `next.config.ts` blog-post matcher fixed so cache tags apply to real post URLs (feeds excluded).
- **Case study twins** — All five `content/case-studies/*.md` files expanded to text-equivalent parity with their React pages.

## Deploy notes

Set `NETLIFY_PURGE_TOKEN` and `NETLIFY_SITE_ID` in Netlify env before relying on CDN purge. Without them, ISR still runs; edge cache may lag until TTL.

## Test plan

- [x] `yarn type-check`
- [x] `yarn build`
- [ ] Post-deploy `curl -sI` on `/llms.txt`, a blog post, and a case study — confirm TTL and `netlify-cache-tag`
- [ ] Cosmic test publish — webhook returns `purgeOk: true`
- [ ] Spot-check a case study `.md` twin against its HTML page

Plan: `rosey/plans/2026-06-23-seo-phase-6-cache-twins-plan.md`