### PR TITLE
Fix Spanish copy and grammar in X Aggregator

### DIFF
--- a/app/api/xaggregator/image/route.ts
+++ b/app/api/xaggregator/image/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
 
   if (!rawUrl) {
     return NextResponse.json(
-      { error: "Falta el parámetro url" },
+      { error: "Falta el parámetro URL" },
       { status: 400 }
     );
   }

--- a/app/api/xaggregator/route.ts
+++ b/app/api/xaggregator/route.ts
@@ -27,7 +27,7 @@ const bodySchema = yup
           .matches(tweetUrlPattern, "URL de tweet no válida")
       )
       .min(1, "Se requiere al menos una URL de tweet")
-      .max(MAX_URLS, `Máximo ${MAX_URLS} URLs de tweets permitidas`)
+      .max(MAX_URLS, `Máximo ${MAX_URLS} URLs de tweet permitidas`)
       .required(),
   })
   .required();
@@ -50,7 +50,7 @@ export async function POST(request: NextRequest) {
     if (!(await isSchemaValid(bodySchema, body))) {
       return NextResponse.json(
         {
-          error: `Solicitud no válida. Proporciona entre 1 y ${MAX_URLS} URLs de tweets.`,
+          error: `Solicitud no válida. Proporciona entre 1 y ${MAX_URLS} URLs de tweet.`,
         },
         { status: 400 }
       );

--- a/components/Apps/Xaggregator/XaggregatorTool.tsx
+++ b/components/Apps/Xaggregator/XaggregatorTool.tsx
@@ -101,7 +101,7 @@ export default function XaggregatorTool() {
       return;
     }
     if (urls.length > MAX_URLS) {
-      setFormError(`Máximo ${MAX_URLS} URLs de tweets permitidas.`);
+      setFormError(`Máximo ${MAX_URLS} URLs de tweet permitidas.`);
       return;
     }
 
@@ -123,7 +123,7 @@ export default function XaggregatorTool() {
         return;
       }
       if (!response.ok) {
-        setFormError(payload.error ?? "La solicitud falló.");
+        setFormError(payload.error ?? "No se pudo procesar la solicitud.");
         setResults([]);
         return;
       }
@@ -167,6 +167,8 @@ export default function XaggregatorTool() {
       showMessage(
         `Se ${succeeded === 1 ? "descargó" : "descargaron"} ${succeeded} imagen${succeeded === 1 ? "" : "es"}.`
       );
+    } else if (succeeded === 0) {
+      showMessage("No se pudo descargar ninguna imagen.");
     } else {
       showMessage(
         `Se descargaron ${succeeded} de ${imageUrls.length} imagen${imageUrls.length === 1 ? "" : "es"}.`
@@ -184,19 +186,19 @@ export default function XaggregatorTool() {
     <Section>
       <SectionTitle main>Agregador de X</SectionTitle>
       <p className="mb-6 text-lg font-light text-gray-700">
-        Esta es una iniciativa para facilitar la extracción de texto y imágenes
-        de tweets en el marco de la emergencia por el terremoto en Venezuela
-        2026. Dale uso prudente.
+        Esta es una iniciativa para facilitar la extracción de texto e imágenes
+        de tweets en el marco de la emergencia causada por el terremoto de 2026
+        en Venezuela. Úsala con prudencia.
       </p>
       <p className="mb-6 text-lg font-light text-gray-700">
-        Pega hasta {MAX_URLS} URLs de tweets (una por línea) para obtener el
+        Pega hasta {MAX_URLS} URLs de tweet (una por línea) para obtener el
         texto y las imágenes.
       </p>
 
       <form onSubmit={handleSubmit} className="mb-8 space-y-4">
         <label className="block w-full">
           <span className="mb-2 block text-sm font-medium text-gray-700">
-            URLs de tweets ({urlCount}/{MAX_URLS})
+            URLs de tweet ({urlCount}/{MAX_URLS})
           </span>
           <textarea
             className="min-h-[160px] w-full rounded-xl border border-gray-200 bg-white p-4 font-mono text-sm focus:border-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-200"

--- a/lib/xaggregator/fetchTweet.ts
+++ b/lib/xaggregator/fetchTweet.ts
@@ -69,7 +69,7 @@ export async function fetchTweet(
     return {
       ok: false,
       error: "upstream",
-      message: "No se pudo contactar el servicio de sindicación",
+      message: "No se pudo contactar con el servicio de sindicación",
     };
   } finally {
     clearTimeout(timeout);


### PR DESCRIPTION
## Summary

- Fix conjunction: *texto **e** imágenes*
- Clarify emergency intro (*emergencia causada por el terremoto de 2026 en Venezuela*) and closing (*Úsala con prudencia*)
- Unify phrasing to *URL de tweet* / *URLs de tweet* across UI and API validation
- Polish error messages (*contactar **con** el servicio*, *parámetro URL*, *No se pudo procesar la solicitud*)
- Add clearer message when all image downloads fail

## Test plan

- [ ] Visit `/apps/xaggregator` and confirm intro copy reads naturally
- [ ] Submit invalid/valid URLs and spot-check Spanish error strings
- [ ] Trigger a failed image download batch and confirm zero-success message