### PR TITLE
Document gitchangelog commit tags and fix release notes awk

### DIFF
--- a/.gitchangelog.rc
+++ b/.gitchangelog.rc
@@ -5,7 +5,16 @@
 ##
 ## ACTION is one of '[REF]', '[FIX]', '[ADD]', '[DEL]'.
 ##
-
+## HISTORY sections (from ACTION):
+##   [ADD] → Added   — new user-facing capability
+##   [FIX] → Fixed   — bug or broken behavior
+##   [REF] → Changed — behavior change that is not a new feature
+##   [DEL] → Removed
+##
+## Omit from HISTORY: append !cosmetic / !refactor / !wip / !minor,
+## or use a CI: subject prefix (see ignore_regexps below).
+## Untagged subjects land in Other — prefer a tag or an ignore marker.
+##
 ignore_regexps = [
     r'^(.{3,3}\s*:)?\s*(\[[A-Z]+\]\s*)?[Uu]pdating [Cc]hangelog and [Vv]ersion.*$',
     r'^(.{3,3}\s*:)?\s*[fF]irst commit.?\s*$',

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -447,7 +447,7 @@ jobs:
               return;
             }
 
-            const patGithub = github.getOctokit(pat);
+            const patGithub = getOctokit(pat);
             try {
               await patGithub.rest.pulls.updateBranch({
                 owner: context.repo.owner,

--- a/MAINTAINER.md
+++ b/MAINTAINER.md
@@ -5,10 +5,23 @@ setup lives in **rosey-maintainer-tools**.
 
 ## Feature work
 
-1. `rosey-lfg-code` — brainstorm → plan → implement.
-2. `rosey-lfg-quality` — QA, lint/build, open/update PR to `develop`.
+1. `rosey-brainstorm` → `rosey-plan` → `rosey-work` — brainstorm → plan → implement.
+2. `rosey-qa` → `rosey-pr` — QA, lint/build, open/update PR to `develop`.
 
 Repeat until ready to ship.
+
+## Commit messages
+
+Subjects feed `HISTORY.md` via gitchangelog, then GitHub release notes on `make release-*`.
+
+| Tag | Section | Use for |
+| --- | ------- | ------- |
+| `[ADD]` | Added | New user-facing capability |
+| `[FIX]` | Fixed | Bug or broken behavior |
+| `[REF]` | Changed | Behavior change that is not a new feature |
+| `[DEL]` | Removed | Removal |
+
+Format: `[TAG] Imperative user-facing summary.` Non-user-facing work (deps, lint, sync, CI): append `!cosmetic` / `!refactor` / `!wip`, or use a `CI:` prefix, so it is omitted from HISTORY. PR titles may stay Conventional-style; only commit subjects use these tags.
 
 ## Release
 
@@ -30,7 +43,7 @@ Post-bump hooks: `.bumpversion.cfg` → `[rosey-maintainer]`.
 - **Auto-merge** — `pr-auto-merge.yml` after that workflow succeeds; head
   `feature/**` or `dependabot/**` only. Actor allowlist: `dependabot[bot]`,
   `cursor[bot]`, `LuisAlejandro`, repository owner.
-  `rosey-lfg-quality` / `rosey-pr` do not merge or fix CI.
+  `rosey-qa` / `rosey-pr` do not merge or fix CI.
 - **Cursor CI fixes** — **rosey-maintainer-tools** `docs/cursor-pr-ci-automation.md`.
 
 ### Auto-merge behavior

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -193,7 +193,7 @@ release_build_notes() {
     fi
 
     if [[ -f "HISTORY.md" ]]; then
-        release_content=$(awk "/^$new_version \(/ { flag=1; next } flag && /^[0-9]+\.[0-9]+\.[0-9]+ \(/ { exit } flag" HISTORY.md)
+        release_content=$(awk "/^#+ *$new_version \(/ { flag=1; next } flag && /^#+ *[0-9]+\.[0-9]+\.[0-9]+ \(/ { exit } flag" HISTORY.md)
         printf '%s\n\n## What'\''s new in %s\n%s\n\nRead [HISTORY](HISTORY.md) for more info.\n\n**Full Changelog**: https://github.com/%s/compare/%s...%s' \
             "$description_text" \
             "$new_version" \


### PR DESCRIPTION
## Summary
- Document `[ADD]`/`[FIX]`/`[REF]`/`[DEL]` commit subjects in MAINTAINER and `.gitchangelog.rc` so HISTORY and GitHub release notes bucket correctly.
- Fix `scripts/lib.sh` awk for markdown HISTORY headers (`## x.y.z`) when extracting release notes.
- Replace dead `rosey-lfg-*` skill names with current pipeline skills (closed-source MAINTAINER only).

## Test plan
- [ ] Confirm MAINTAINER commit-message section renders as expected
- [ ] Spot-check `.gitchangelog.rc` header comments
- [ ] (MD HISTORY repos) Confirm `release_build_notes` awk matches `## version (` headers