### PR TITLE
Set up and verify cloud dev environment

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -20,4 +20,5 @@ Personal website and portfolio: a single Next.js 16 (App Router) + TypeScript + 
 
 - `make release-preflight` chains `lint`, `format`, and `test`; CI PR workflow builds the Docker image and runs a production build (`.github/workflows/pr.yml`).
 - Pages backed by Cosmic will error or show empty content without valid `COSMIC_BUCKET_SLUG` and `COSMIC_READ_KEY` in `.env`.
+- Even without any secrets configured, these surfaces work for quick end-to-end smoke tests: the homepage (`/`), the contact page/form (`/contact`, renders and accepts input; actual submission needs reCAPTCHA + SES), the static routes (`/robots.txt`, `/sitemap.xml`, `/.well-known/api-catalog`), and the built-in MCP server at `POST /api/mcp` (JSON-RPC `initialize`/`tools/list` respond). Requests must send `Accept: application/json, text/event-stream`.
 - Sentry is wired via `@sentry/nextjs`; builds may warn if DSN-related env is missing — that is expected in a minimal local setup.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up and verified the development environment for this Next.js 16 personal website in a fresh Cursor Cloud VM, and ran the app end to end.

- Installed dependencies with `npm install` (1037 packages, native builds `bcrypt`/`sharp` included).
- Copied `.env` from `.env.example` (git-ignored; not committed).
- Ran the dev server with `PORT=3101 npm run dev` → http://localhost:3101.

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Lint | `npm run lint` | Pass (no errors) |
| Type-check | `npm run type-check` | Pass (no errors) |
| Dev server | `PORT=3101 npm run dev` | Ready, homepage `200` |
| MCP endpoint | `POST /api/mcp` (JSON-RPC `initialize`) | Valid response |
| Static routes | `/robots.txt`, `/sitemap.xml`, `/.well-known/api-catalog` | `200` |

## End-to-end demo

Loaded the homepage, navigated to `/contact`, and filled the contact form (Name/Email/Message) — a core interactive feature that works without external secrets.

[homepage_and_contact_form_demo.mp4](https://cursor.com/agents/bc-a74199a5-5748-4ab4-9393-6e6efa2afe8c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_and_contact_form_demo.mp4)

[Homepage hero](https://cursor.com/agents/bc-a74199a5-5748-4ab4-9393-6e6efa2afe8c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_hero.webp)
[Contact form filled](https://cursor.com/agents/bc-a74199a5-5748-4ab4-9393-6e6efa2afe8c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcontact_form_filled.webp)

## Changes

- `.cursorrules`: added a note about which surfaces (homepage, `/contact`, static routes, and the `/api/mcp` MCP server) can be smoke-tested without any secrets configured. No application code changed.

The startup update script is `npm install`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a74199a5-5748-4ab4-9393-6e6efa2afe8c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a74199a5-5748-4ab4-9393-6e6efa2afe8c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

